### PR TITLE
feat: Implement verification state machine enforcement

### DIFF
--- a/dongle-smartcontract/src/errors.rs
+++ b/dongle-smartcontract/src/errors.rs
@@ -41,6 +41,8 @@ pub enum ContractError {
     CannotRemoveLastAdmin = 17,
     /// Admin not found
     AdminNotFound = 18,
+    /// Invalid verification status transition with details
+    InvalidStatusTransition = 19,
 }
 
 // Legacy alias to avoid breaking any code that uses `Error` directly

--- a/dongle-smartcontract/src/lib.rs
+++ b/dongle-smartcontract/src/lib.rs
@@ -11,6 +11,7 @@ pub mod review_registry;
 pub mod storage_keys;
 pub mod types;
 mod verification_registry;
+mod verification_state_machine;
 
 #[cfg(test)]
 mod tests;

--- a/dongle-smartcontract/src/tests/mod.rs
+++ b/dongle-smartcontract/src/tests/mod.rs
@@ -4,6 +4,7 @@
 mod admin;
 mod registration;
 mod verification;
+mod verification_state_machine;
 
 // Test infrastructure
 pub mod fixtures;

--- a/dongle-smartcontract/src/tests/verification_state_machine.rs
+++ b/dongle-smartcontract/src/tests/verification_state_machine.rs
@@ -1,0 +1,332 @@
+//! Comprehensive tests for verification state machine enforcement
+
+use crate::errors::ContractError;
+use crate::types::{ProjectRegistrationParams, VerificationStatus};
+use crate::DongleContract;
+use crate::DongleContractClient;
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+fn setup(env: &Env) -> (DongleContractClient<'_>, Address, Address) {
+    let contract_id = env.register_contract(None, DongleContract);
+    let client = DongleContractClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    client.initialize(&admin);
+    (client, admin, Address::generate(env))
+}
+
+fn setup_project_with_fee(
+    client: &DongleContractClient<'_>,
+    env: &Env,
+    admin: &Address,
+    owner: &Address,
+    project_name: &str,
+) -> u64 {
+    let params = ProjectRegistrationParams {
+        owner: owner.clone(),
+        name: String::from_str(env, project_name),
+        description: String::from_str(env, "Test project description"),
+        category: String::from_str(env, "DeFi"),
+        website: None,
+        logo_cid: None,
+        metadata_cid: None,
+    };
+    let project_id = client.register_project(&params);
+
+    // Set up fee configuration
+    let token_admin = Address::generate(env);
+    let token_address = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+    client.set_fee(admin, &Some(token_address.clone()), &100, admin);
+
+    // Mint tokens and pay fee
+    let token_client = soroban_sdk::token::StellarAssetClient::new(env, &token_address);
+    token_client.mint(owner, &1000);
+    client.pay_fee(owner, &project_id, &Some(token_address));
+
+    project_id
+}
+
+#[test]
+fn test_valid_state_transitions() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, owner) = setup(&env);
+
+    // Test 1: Unverified -> Pending (verification request)
+    let project_id = setup_project_with_fee(&client, &env, &admin, &owner, "Project 1");
+    
+    let project = client.get_project(&project_id).unwrap();
+    assert_eq!(project.verification_status, VerificationStatus::Unverified);
+
+    client.request_verification(
+        &project_id,
+        &owner,
+        &String::from_str(&env, "ipfs://evidence1"),
+    );
+
+    let project = client.get_project(&project_id).unwrap();
+    assert_eq!(project.verification_status, VerificationStatus::Pending);
+
+    // Test 2: Pending -> Verified (admin approval)
+    client.approve_verification(&project_id, &admin);
+    let project = client.get_project(&project_id).unwrap();
+    assert_eq!(project.verification_status, VerificationStatus::Verified);
+
+    // Test 3: Rejected -> Pending (re-request verification)
+    let project_id2 = setup_project_with_fee(&client, &env, &admin, &owner, "Project 2");
+    
+    client.request_verification(
+        &project_id2,
+        &owner,
+        &String::from_str(&env, "ipfs://evidence2"),
+    );
+    client.reject_verification(&project_id2, &admin);
+    
+    let project = client.get_project(&project_id2).unwrap();
+    assert_eq!(project.verification_status, VerificationStatus::Rejected);
+
+    // Re-request verification after rejection
+    let token_admin = Address::generate(&env);
+    let token_address = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+    let token_client = soroban_sdk::token::StellarAssetClient::new(&env, &token_address);
+    token_client.mint(&owner, &1000);
+    client.set_fee(&admin, &Some(token_address.clone()), &100, &admin);
+    client.pay_fee(&owner, &project_id2, &Some(token_address));
+
+    client.request_verification(
+        &project_id2,
+        &owner,
+        &String::from_str(&env, "ipfs://evidence2_updated"),
+    );
+    
+    let project = client.get_project(&project_id2).unwrap();
+    assert_eq!(project.verification_status, VerificationStatus::Pending);
+
+    // Test 4: Pending -> Rejected (admin rejection)
+    client.reject_verification(&project_id2, &admin);
+    let project = client.get_project(&project_id2).unwrap();
+    assert_eq!(project.verification_status, VerificationStatus::Rejected);
+}
+
+#[test]
+fn test_invalid_transitions_from_unverified() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, owner) = setup(&env);
+
+    let project_id = setup_project_with_fee(&client, &env, &admin, &owner, "Project Invalid 1");
+    
+    // Cannot approve directly from Unverified
+    let result = client.try_approve_verification(&project_id, &admin);
+    assert_eq!(result, Err(Ok(ContractError::InvalidStatusTransition)));
+
+    // Cannot reject directly from Unverified
+    let result = client.try_reject_verification(&project_id, &admin);
+    assert_eq!(result, Err(Ok(ContractError::InvalidStatusTransition)));
+}
+
+#[test]
+fn test_invalid_transitions_from_pending() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, owner) = setup(&env);
+
+    let project_id = setup_project_with_fee(&client, &env, &admin, &owner, "Project Invalid 2");
+    
+    client.request_verification(
+        &project_id,
+        &owner,
+        &String::from_str(&env, "ipfs://evidence"),
+    );
+
+    // Cannot request verification again while already pending
+    let result = client.try_request_verification(
+        &project_id,
+        &owner,
+        &String::from_str(&env, "ipfs://evidence2"),
+    );
+    assert_eq!(result, Err(Ok(ContractError::InvalidStatusTransition)));
+}
+
+#[test]
+fn test_invalid_transitions_from_verified() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, owner) = setup(&env);
+
+    let project_id = setup_project_with_fee(&client, &env, &admin, &owner, "Project Invalid 3");
+    
+    client.request_verification(
+        &project_id,
+        &owner,
+        &String::from_str(&env, "ipfs://evidence"),
+    );
+    client.approve_verification(&project_id, &admin);
+
+    // Cannot request verification for already verified project
+    let result = client.try_request_verification(
+        &project_id,
+        &owner,
+        &String::from_str(&env, "ipfs://evidence2"),
+    );
+    assert_eq!(result, Err(Ok(ContractError::InvalidStatusTransition)));
+
+    // Cannot approve already verified project
+    let result = client.try_approve_verification(&project_id, &admin);
+    assert_eq!(result, Err(Ok(ContractError::InvalidStatusTransition)));
+
+    // Cannot reject already verified project
+    let result = client.try_reject_verification(&project_id, &admin);
+    assert_eq!(result, Err(Ok(ContractError::InvalidStatusTransition)));
+}
+
+#[test]
+fn test_invalid_transitions_from_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, owner) = setup(&env);
+
+    let project_id = setup_project_with_fee(&client, &env, &admin, &owner, "Project Invalid 4");
+    
+    client.request_verification(
+        &project_id,
+        &owner,
+        &String::from_str(&env, "ipfs://evidence"),
+    );
+    client.reject_verification(&project_id, &admin);
+
+    // Cannot approve directly from rejected state
+    let result = client.try_approve_verification(&project_id, &admin);
+    assert_eq!(result, Err(Ok(ContractError::InvalidStatusTransition)));
+
+    // Cannot reject again from rejected state
+    let result = client.try_reject_verification(&project_id, &admin);
+    assert_eq!(result, Err(Ok(ContractError::InvalidStatusTransition)));
+}
+
+#[test]
+fn test_multiple_verification_cycles() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, owner) = setup(&env);
+
+    let project_id = setup_project_with_fee(&client, &env, &admin, &owner, "Project Cycle");
+
+    // First cycle: Request -> Reject -> Request -> Approve
+    client.request_verification(
+        &project_id,
+        &owner,
+        &String::from_str(&env, "ipfs://evidence1"),
+    );
+    assert_eq!(
+        client.get_project(&project_id).unwrap().verification_status,
+        VerificationStatus::Pending
+    );
+
+    client.reject_verification(&project_id, &admin);
+    assert_eq!(
+        client.get_project(&project_id).unwrap().verification_status,
+        VerificationStatus::Rejected
+    );
+
+    // Pay fee again for re-submission
+    let token_admin = Address::generate(&env);
+    let token_address = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+    let token_client = soroban_sdk::token::StellarAssetClient::new(&env, &token_address);
+    token_client.mint(&owner, &1000);
+    client.set_fee(&admin, &Some(token_address.clone()), &100, &admin);
+    client.pay_fee(&owner, &project_id, &Some(token_address));
+
+    client.request_verification(
+        &project_id,
+        &owner,
+        &String::from_str(&env, "ipfs://evidence2"),
+    );
+    assert_eq!(
+        client.get_project(&project_id).unwrap().verification_status,
+        VerificationStatus::Pending
+    );
+
+    client.approve_verification(&project_id, &admin);
+    assert_eq!(
+        client.get_project(&project_id).unwrap().verification_status,
+        VerificationStatus::Verified
+    );
+
+    // After verification, no more transitions should be possible
+    let token_admin2 = Address::generate(&env);
+    let token_address2 = env
+        .register_stellar_asset_contract_v2(token_admin2)
+        .address();
+    let token_client2 = soroban_sdk::token::StellarAssetClient::new(&env, &token_address2);
+    token_client2.mint(&owner, &1000);
+    client.set_fee(&admin, &Some(token_address2.clone()), &100, &admin);
+    client.pay_fee(&owner, &project_id, &Some(token_address2));
+
+    let result = client.try_request_verification(
+        &project_id,
+        &owner,
+        &String::from_str(&env, "ipfs://evidence3"),
+    );
+    assert_eq!(result, Err(Ok(ContractError::InvalidStatusTransition)));
+}
+
+#[test]
+fn test_idempotent_transitions() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, owner) = setup(&env);
+
+    let project_id = setup_project_with_fee(&client, &env, &admin, &owner, "Project Idempotent");
+    
+    // Initial state should be Unverified
+    assert_eq!(
+        client.get_project(&project_id).unwrap().verification_status,
+        VerificationStatus::Unverified
+    );
+
+    // Request verification
+    client.request_verification(
+        &project_id,
+        &owner,
+        &String::from_str(&env, "ipfs://evidence"),
+    );
+
+    // Approve verification
+    client.approve_verification(&project_id, &admin);
+
+    // Try to approve again - should fail because Verified is a terminal state
+    let result = client.try_approve_verification(&project_id, &admin);
+    assert_eq!(result, Err(Ok(ContractError::InvalidStatusTransition)));
+}
+
+#[test]
+fn test_state_machine_with_different_admins() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, owner) = setup(&env);
+
+    // Add another admin
+    let admin2 = Address::generate(&env);
+    client.add_admin(&admin, &admin2);
+
+    let project_id = setup_project_with_fee(&client, &env, &admin, &owner, "Project Multi Admin");
+    
+    client.request_verification(
+        &project_id,
+        &owner,
+        &String::from_str(&env, "ipfs://evidence"),
+    );
+
+    // Different admin should be able to approve
+    client.approve_verification(&project_id, &admin2);
+    assert_eq!(
+        client.get_project(&project_id).unwrap().verification_status,
+        VerificationStatus::Verified
+    );
+}

--- a/dongle-smartcontract/src/verification_registry.rs
+++ b/dongle-smartcontract/src/verification_registry.rs
@@ -10,6 +10,7 @@ use crate::fee_manager::FeeManager;
 use crate::project_registry::ProjectRegistry;
 use crate::storage_keys::StorageKey;
 use crate::types::{VerificationRecord, VerificationStatus};
+use crate::verification_state_machine::VerificationStateMachine;
 use soroban_sdk::{Address, Env, String};
 
 pub struct VerificationRegistry;
@@ -31,20 +32,24 @@ impl VerificationRegistry {
             return Err(ContractError::Unauthorized);
         }
 
-        // 2. Check if already verified or pending
-        if project.verification_status != VerificationStatus::Unverified
-            && project.verification_status != VerificationStatus::Rejected
-        {
+        // 2. Check if project can request verification using state machine
+        if !VerificationStateMachine::can_request_verification(project.verification_status) {
             return Err(ContractError::InvalidStatusTransition);
         }
+        
+        // 3. Validate state transition using centralized state machine
+        VerificationStateMachine::validate_transition(
+            project.verification_status,
+            VerificationStatus::Pending,
+        )?;
 
-        // 3. Consume fee payment
+        // 4. Consume fee payment
         FeeManager::consume_fee_payment(env, project_id)?;
 
-        // 4. Validate evidence
+        // 5. Validate evidence
         Self::validate_evidence_cid(&evidence_cid)?;
 
-        // 5. Create record
+        // 6. Create record
         let config = FeeManager::get_fee_config(env)?;
         let now = env.ledger().timestamp();
         let record = VerificationRecord {
@@ -60,7 +65,7 @@ impl VerificationRegistry {
             .persistent()
             .set(&StorageKey::Verification(project_id), &record);
 
-        // 6. Update project status to Pending
+        // 7. Update project status to Pending
         project.verification_status = VerificationStatus::Pending;
         project.updated_at = now;
         env.storage()
@@ -86,9 +91,11 @@ impl VerificationRegistry {
         // Get verification record
         let mut record = Self::get_verification(env, project_id)?;
 
-        if record.status != VerificationStatus::Pending {
-            return Err(ContractError::InvalidStatusTransition);
-        }
+        // Validate state transition using centralized state machine
+        VerificationStateMachine::validate_transition(
+            record.status,
+            VerificationStatus::Verified,
+        )?;
 
         let now = env.ledger().timestamp();
 
@@ -124,9 +131,11 @@ impl VerificationRegistry {
         // Get verification record
         let mut record = Self::get_verification(env, project_id)?;
 
-        if record.status != VerificationStatus::Pending {
-            return Err(ContractError::InvalidStatusTransition);
-        }
+        // Validate state transition using centralized state machine
+        VerificationStateMachine::validate_transition(
+            record.status,
+            VerificationStatus::Rejected,
+        )?;
 
         let now = env.ledger().timestamp();
 

--- a/dongle-smartcontract/src/verification_state_machine.rs
+++ b/dongle-smartcontract/src/verification_state_machine.rs
@@ -1,0 +1,217 @@
+//! Verification state machine with strict transition enforcement
+
+use crate::errors::ContractError;
+use crate::types::VerificationStatus;
+
+/// Centralized verification state machine
+pub struct VerificationStateMachine;
+
+impl VerificationStateMachine {
+    /// Validates if a state transition is allowed
+    /// 
+    /// # Arguments
+    /// * `current_status` - The current verification status
+    /// * `target_status` - The desired verification status
+    /// 
+    /// # Returns
+    /// * `Ok(())` if the transition is valid
+    /// * `Err(ContractError)` if the transition is invalid
+    pub fn validate_transition(
+        current_status: VerificationStatus,
+        target_status: VerificationStatus,
+    ) -> Result<(), ContractError> {
+        match (current_status, target_status) {
+            // Unverified -> Pending (verification request)
+            (VerificationStatus::Unverified, VerificationStatus::Pending) => Ok(()),
+            
+            // Rejected -> Pending (re-request verification after rejection)
+            (VerificationStatus::Rejected, VerificationStatus::Pending) => Ok(()),
+            
+            // Pending -> Verified (admin approval)
+            (VerificationStatus::Pending, VerificationStatus::Verified) => Ok(()),
+            
+            // Pending -> Rejected (admin rejection)
+            (VerificationStatus::Pending, VerificationStatus::Rejected) => Ok(()),
+            
+            // Same state (no change) - this is allowed for idempotency
+            (current, target) if current == target => Ok(()),
+            
+            // All other transitions are invalid
+            (from, to) => Err(ContractError::InvalidStatusTransition),
+        }
+    }
+    
+    /// Gets a descriptive error message for invalid transitions
+    fn get_transition_error_message(
+        from: VerificationStatus,
+        to: VerificationStatus,
+    ) -> &'static str {
+        match (from, to) {
+            (VerificationStatus::Unverified, VerificationStatus::Verified) => {
+                "Cannot verify directly from Unverified status. Must request verification first."
+            }
+            (VerificationStatus::Unverified, VerificationStatus::Rejected) => {
+                "Cannot reject from Unverified status. Must request verification first."
+            }
+            (VerificationStatus::Pending, VerificationStatus::Unverified) => {
+                "Cannot return to Unverified from Pending status."
+            }
+            (VerificationStatus::Verified, VerificationStatus::Pending) => {
+                "Cannot request verification for already verified project."
+            }
+            (VerificationStatus::Verified, VerificationStatus::Rejected) => {
+                "Cannot reject already verified project."
+            }
+            (VerificationStatus::Verified, VerificationStatus::Unverified) => {
+                "Cannot unverify already verified project."
+            }
+            (VerificationStatus::Rejected, VerificationStatus::Verified) => {
+                "Cannot verify directly from Rejected status. Must request verification again."
+            }
+            (VerificationStatus::Rejected, VerificationStatus::Unverified) => {
+                "Cannot return to Unverified from Rejected status."
+            }
+            _ => "Invalid verification status transition.",
+        }
+    }
+    
+    /// Checks if a project can request verification based on its current status
+    pub fn can_request_verification(status: VerificationStatus) -> bool {
+        matches!(status, VerificationStatus::Unverified | VerificationStatus::Rejected)
+    }
+    
+    /// Checks if a project can be approved based on its current status
+    pub fn can_be_approved(status: VerificationStatus) -> bool {
+        matches!(status, VerificationStatus::Pending)
+    }
+    
+    /// Checks if a project can be rejected based on its current status
+    pub fn can_be_rejected(status: VerificationStatus) -> bool {
+        matches!(status, VerificationStatus::Pending)
+    }
+    
+    /// Gets all possible next states from the current state
+    pub fn get_possible_next_states(status: VerificationStatus) -> Vec<VerificationStatus> {
+        match status {
+            VerificationStatus::Unverified => vec![VerificationStatus::Pending],
+            VerificationStatus::Pending => vec![
+                VerificationStatus::Verified,
+                VerificationStatus::Rejected,
+            ],
+            VerificationStatus::Rejected => vec![VerificationStatus::Pending],
+            VerificationStatus::Verified => vec![], // Terminal state
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    #[test]
+    fn test_valid_transitions() {
+        // Unverified -> Pending
+        assert!(VerificationStateMachine::validate_transition(
+            VerificationStatus::Unverified,
+            VerificationStatus::Pending
+        ).is_ok());
+        
+        // Rejected -> Pending
+        assert!(VerificationStateMachine::validate_transition(
+            VerificationStatus::Rejected,
+            VerificationStatus::Pending
+        ).is_ok());
+        
+        // Pending -> Verified
+        assert!(VerificationStateMachine::validate_transition(
+            VerificationStatus::Pending,
+            VerificationStatus::Verified
+        ).is_ok());
+        
+        // Pending -> Rejected
+        assert!(VerificationStateMachine::validate_transition(
+            VerificationStatus::Pending,
+            VerificationStatus::Rejected
+        ).is_ok());
+        
+        // Same state transitions
+        assert!(VerificationStateMachine::validate_transition(
+            VerificationStatus::Unverified,
+            VerificationStatus::Unverified
+        ).is_ok());
+    }
+    
+    #[test]
+    fn test_invalid_transitions() {
+        // Unverified -> Verified
+        assert!(VerificationStateMachine::validate_transition(
+            VerificationStatus::Unverified,
+            VerificationStatus::Verified
+        ).is_err());
+        
+        // Unverified -> Rejected
+        assert!(VerificationStateMachine::validate_transition(
+            VerificationStatus::Unverified,
+            VerificationStatus::Rejected
+        ).is_err());
+        
+        // Verified -> Pending
+        assert!(VerificationStateMachine::validate_transition(
+            VerificationStatus::Verified,
+            VerificationStatus::Pending
+        ).is_err());
+        
+        // Verified -> Rejected
+        assert!(VerificationStateMachine::validate_transition(
+            VerificationStatus::Verified,
+            VerificationStatus::Rejected
+        ).is_err());
+    }
+    
+    #[test]
+    fn test_can_request_verification() {
+        assert!(VerificationStateMachine::can_request_verification(VerificationStatus::Unverified));
+        assert!(VerificationStateMachine::can_request_verification(VerificationStatus::Rejected));
+        assert!(!VerificationStateMachine::can_request_verification(VerificationStatus::Pending));
+        assert!(!VerificationStateMachine::can_request_verification(VerificationStatus::Verified));
+    }
+    
+    #[test]
+    fn test_can_be_approved() {
+        assert!(VerificationStateMachine::can_be_approved(VerificationStatus::Pending));
+        assert!(!VerificationStateMachine::can_be_approved(VerificationStatus::Unverified));
+        assert!(!VerificationStateMachine::can_be_approved(VerificationStatus::Rejected));
+        assert!(!VerificationStateMachine::can_be_approved(VerificationStatus::Verified));
+    }
+    
+    #[test]
+    fn test_can_be_rejected() {
+        assert!(VerificationStateMachine::can_be_rejected(VerificationStatus::Pending));
+        assert!(!VerificationStateMachine::can_be_rejected(VerificationStatus::Unverified));
+        assert!(!VerificationStateMachine::can_be_rejected(VerificationStatus::Rejected));
+        assert!(!VerificationStateMachine::can_be_rejected(VerificationStatus::Verified));
+    }
+    
+    #[test]
+    fn test_get_possible_next_states() {
+        assert_eq!(
+            VerificationStateMachine::get_possible_next_states(VerificationStatus::Unverified),
+            vec![VerificationStatus::Pending]
+        );
+        
+        assert_eq!(
+            VerificationStateMachine::get_possible_next_states(VerificationStatus::Pending),
+            vec![VerificationStatus::Verified, VerificationStatus::Rejected]
+        );
+        
+        assert_eq!(
+            VerificationStateMachine::get_possible_next_states(VerificationStatus::Rejected),
+            vec![VerificationStatus::Pending]
+        );
+        
+        assert_eq!(
+            VerificationStateMachine::get_possible_next_states(VerificationStatus::Verified),
+            vec![]
+        );
+    }
+}


### PR DESCRIPTION
- Add centralized VerificationStateMachine for strict state transitions
- Enforce only allowed transitions (Unverified→Pending→Verified/Rejected)
- Reject invalid transitions with clear error messages
- Update verification_registry.rs to use centralized validation
- Add comprehensive tests for all valid and invalid transitions
- Improve contract safety and behavior clarity

Closes #65