### PR TITLE
feat: add batch query functions for indexer support

### DIFF
--- a/dongle-smartcontract/src/lib.rs
+++ b/dongle-smartcontract/src/lib.rs
@@ -26,7 +26,7 @@ use crate::review_registry::ReviewRegistry;
 use crate::storage_manager::StorageManager;
 use crate::types::{
     FeeConfig, Project, ProjectRegistrationParams, ProjectStats, ProjectUpdateParams, Review,
-    VerificationRecord,
+    VerificationRecord, VerificationStatus,
 };
 use crate::verification_registry::VerificationRegistry;
 use soroban_sdk::{contract, contractimpl, Address, Env, String, Vec};
@@ -95,6 +95,19 @@ impl DongleContract {
         ProjectRegistry::get_owner_project_count(&env, &owner)
     }
 
+    pub fn get_projects_by_ids(env: Env, ids: Vec<u64>) -> Vec<Project> {
+        ProjectRegistry::get_projects_by_ids(&env, ids)
+    }
+
+    pub fn list_projects_by_verification_status(
+        env: Env,
+        status: VerificationStatus,
+        start_id: u64,
+        limit: u32,
+    ) -> Vec<Project> {
+        ProjectRegistry::list_projects_by_verification_status(&env, status, start_id, limit)
+    }
+
     // --- Review Registry ---
 
     pub fn add_review(
@@ -127,6 +140,10 @@ impl DongleContract {
 
     pub fn get_review(env: Env, project_id: u64, reviewer: Address) -> Option<Review> {
         ReviewRegistry::get_review(&env, project_id, reviewer)
+    }
+
+    pub fn get_reviews_by_ids(env: Env, ids: Vec<(u64, Address)>) -> Vec<Review> {
+        ReviewRegistry::get_reviews_by_ids(&env, ids)
     }
 
     pub fn list_reviews(env: Env, project_id: u64, start_id: u32, limit: u32) -> Vec<Review> {

--- a/dongle-smartcontract/src/lib.rs
+++ b/dongle-smartcontract/src/lib.rs
@@ -99,13 +99,13 @@ impl DongleContract {
         ProjectRegistry::get_projects_by_ids(&env, ids)
     }
 
-    pub fn list_projects_by_verification_status(
+    pub fn list_projects_by_status(
         env: Env,
         status: VerificationStatus,
         start_id: u64,
         limit: u32,
     ) -> Vec<Project> {
-        ProjectRegistry::list_projects_by_verification_status(&env, status, start_id, limit)
+        ProjectRegistry::list_projects_by_status(&env, status, start_id, limit)
     }
 
     // --- Review Registry ---

--- a/dongle-smartcontract/src/project_registry.rs
+++ b/dongle-smartcontract/src/project_registry.rs
@@ -264,6 +264,62 @@ impl ProjectRegistry {
         Self::owner_project_count(env, owner)
     }
 
+    pub fn get_projects_by_ids(env: &Env, ids: Vec<u64>) -> Vec<Project> {
+        let mut projects = Vec::new(env);
+        let len = ids.len();
+        for i in 0..len {
+            if let Some(id) = ids.get(i) {
+                if let Some(project) = Self::get_project(env, id) {
+                    projects.push_back(project);
+                }
+            }
+        }
+        projects
+    }
+
+    pub fn list_projects_by_verification_status(
+        env: &Env,
+        status: VerificationStatus,
+        start_id: u64,
+        limit: u32,
+    ) -> Vec<Project> {
+        let effective_limit = if limit == 0 || limit > MAX_PAGE_LIMIT {
+            MAX_PAGE_LIMIT
+        } else {
+            limit
+        };
+
+        let count: u64 = env
+            .storage()
+            .persistent()
+            .get(&StorageKey::ProjectCount)
+            .unwrap_or(0);
+
+        let mut projects = Vec::new(env);
+        if count == 0 {
+            return projects;
+        }
+
+        let first = if start_id == 0 { 1u64 } else { start_id };
+        if first > count {
+            return projects;
+        }
+
+        let mut collected: u32 = 0;
+        for id in first..=count {
+            if collected >= effective_limit {
+                break;
+            }
+            if let Some(project) = Self::get_project(env, id) {
+                if project.verification_status == status {
+                    projects.push_back(project);
+                    collected += 1;
+                }
+            }
+        }
+        projects
+    }
+
     pub fn list_projects(env: &Env, start_id: u64, limit: u32) -> Vec<Project> {
         // Enforce pagination limits: limit must be 1..=MAX_PAGE_LIMIT
         let effective_limit = if limit == 0 || limit > MAX_PAGE_LIMIT {

--- a/dongle-smartcontract/src/project_registry.rs
+++ b/dongle-smartcontract/src/project_registry.rs
@@ -277,7 +277,7 @@ impl ProjectRegistry {
         projects
     }
 
-    pub fn list_projects_by_verification_status(
+    pub fn list_projects_by_status(
         env: &Env,
         status: VerificationStatus,
         start_id: u64,

--- a/dongle-smartcontract/src/review_registry.rs
+++ b/dongle-smartcontract/src/review_registry.rs
@@ -285,6 +285,19 @@ impl ReviewRegistry {
         Ok(())
     }
 
+    pub fn get_reviews_by_ids(env: &Env, ids: Vec<(u64, Address)>) -> Vec<Review> {
+        let mut reviews = Vec::new(env);
+        let len = ids.len();
+        for i in 0..len {
+            if let Some((project_id, reviewer)) = ids.get(i) {
+                if let Some(review) = Self::get_review(env, project_id, reviewer) {
+                    reviews.push_back(review);
+                }
+            }
+        }
+        reviews
+    }
+
     pub fn get_review(env: &Env, project_id: u64, reviewer: Address) -> Option<Review> {
         env.storage()
             .persistent()


### PR DESCRIPTION

closes #87 
Closes #93

Adds three batch query functions to reduce RPC calls for frontends and indexers.

## Changes

**`project_registry.rs`**
- `get_projects_by_ids(ids: Vec<u64>)` — fetch multiple projects in one call; missing IDs are silently skipped
- `list_projects_by_verification_status(status, start_id, limit)` — paginated filter by `VerificationStatus`, respects `MAX_PAGE_LIMIT`

**`review_registry.rs`**
- `get_reviews_by_ids(ids: Vec<(u64, Address)>)` — batch fetch reviews by `(project_id, reviewer)` pairs; missing entries are silently skipped

**`lib.rs`**
- All three functions exposed as contract entry points
- `VerificationStatus` added to type imports

## Testing

All new functions follow the same patterns as existing `get_project` / `get_review` / `list_projects` functions. No new dependencies introduced.