### PR TITLE
[codex] Store review CID for IPFS reference

### DIFF
--- a/dongle-smartcontract/README.md
+++ b/dongle-smartcontract/README.md
@@ -118,10 +118,13 @@ For complete TTL strategy documentation, see [TTL_STRATEGY.md](../TTL_STRATEGY.m
 
 ### Reviews
 
-- `add_review` - Submit a project review
+- `add_review` - Submit a project review (legacy path using optional CID field)
+- `submit_review` - Submit a review with required IPFS CID
 - `update_review` - Update your review
 - `get_review` - Get a specific review
-- `get_project_reviews` - List project reviews
+- `get_review_cid` - Fetch review CID by project ID and reviewer
+- `get_project_review_cids` - Fetch all reviewer/CID pairs for a project
+- `list_reviews` - List project reviews
 
 ### Verification
 

--- a/dongle-smartcontract/src/lib.rs
+++ b/dongle-smartcontract/src/lib.rs
@@ -138,8 +138,26 @@ impl DongleContract {
         ReviewRegistry::delete_review(&env, project_id, reviewer)
     }
 
+    pub fn submit_review(
+        env: Env,
+        project_id: u64,
+        reviewer: Address,
+        rating: u32,
+        review_cid: String,
+    ) -> Result<(), ContractError> {
+        ReviewRegistry::submit_review(&env, project_id, reviewer, rating, review_cid)
+    }
+
     pub fn get_review(env: Env, project_id: u64, reviewer: Address) -> Option<Review> {
         ReviewRegistry::get_review(&env, project_id, reviewer)
+    }
+
+    pub fn get_review_cid(env: Env, project_id: u64, reviewer: Address) -> Option<String> {
+        ReviewRegistry::get_review_cid(&env, project_id, reviewer)
+    }
+
+    pub fn get_project_review_cids(env: Env, project_id: u64) -> Vec<(Address, String)> {
+        ReviewRegistry::get_project_review_cids(&env, project_id)
     }
 
     pub fn get_reviews_by_ids(env: Env, ids: Vec<(u64, Address)>) -> Vec<Review> {

--- a/dongle-smartcontract/src/review_registry.rs
+++ b/dongle-smartcontract/src/review_registry.rs
@@ -1,17 +1,25 @@
 //! Review registry: create/update/delete reviews and maintain aggregates and indexes.
 
-use crate::constants::{RATING_MAX, RATING_MIN};
+use crate::constants::{MAX_CID_LEN, RATING_MAX, RATING_MIN};
 use crate::errors::ContractError;
 use crate::events::publish_review_event;
 use crate::rating_calculator::RatingCalculator;
 use crate::storage_keys::StorageKey;
 use crate::storage_manager::StorageManager;
 use crate::types::{ProjectStats, Review, ReviewAction};
+use crate::utils::Utils;
 use soroban_sdk::{Address, Env, String, Vec};
 
 pub struct ReviewRegistry;
 
 impl ReviewRegistry {
+    fn validate_review_cid(cid: &String) -> Result<(), ContractError> {
+        if !Utils::is_valid_ipfs_cid(cid) || cid.len() as usize > MAX_CID_LEN {
+            return Err(ContractError::InvalidProjectData);
+        }
+        Ok(())
+    }
+
     pub fn add_review(
         env: &Env,
         project_id: u64,
@@ -19,6 +27,10 @@ impl ReviewRegistry {
         rating: u32,
         comment_cid: Option<String>,
     ) -> Result<(), ContractError> {
+        if let Some(cid) = comment_cid.as_ref() {
+            Self::validate_review_cid(cid)?;
+        }
+
         // Validation phase
         reviewer.require_auth();
 
@@ -37,7 +49,7 @@ impl ReviewRegistry {
             project_id,
             reviewer: reviewer.clone(),
             rating,
-            ipfs_cid: None,
+            ipfs_cid: comment_cid.clone(),
             comment_cid: comment_cid.clone(),
             created_at: now,
             updated_at: now,
@@ -101,12 +113,23 @@ impl ReviewRegistry {
             project_id,
             reviewer,
             ReviewAction::Submitted,
-            None,
+            comment_cid.clone(),
             comment_cid,
             now,
             now,
         );
         Ok(())
+    }
+
+    pub fn submit_review(
+        env: &Env,
+        project_id: u64,
+        reviewer: Address,
+        rating: u32,
+        review_cid: String,
+    ) -> Result<(), ContractError> {
+        Self::validate_review_cid(&review_cid)?;
+        Self::add_review(env, project_id, reviewer, rating, Some(review_cid))
     }
 
     pub fn update_review(
@@ -116,6 +139,10 @@ impl ReviewRegistry {
         rating: u32,
         comment_cid: Option<String>,
     ) -> Result<(), ContractError> {
+        if let Some(cid) = comment_cid.as_ref() {
+            Self::validate_review_cid(cid)?;
+        }
+
         // Validation phase
         reviewer.require_auth();
 
@@ -138,6 +165,7 @@ impl ReviewRegistry {
         let old_rating = review.rating;
         let now = env.ledger().timestamp();
         review.rating = rating;
+        review.ipfs_cid = comment_cid.clone();
         review.comment_cid = comment_cid.clone();
         review.updated_at = now;
 
@@ -176,7 +204,7 @@ impl ReviewRegistry {
             project_id,
             reviewer,
             ReviewAction::Updated,
-            None,
+            comment_cid.clone(),
             comment_cid,
             review.created_at,
             now,
@@ -302,6 +330,35 @@ impl ReviewRegistry {
         env.storage()
             .persistent()
             .get(&StorageKey::Review(project_id, reviewer))
+    }
+
+    pub fn get_review_cid(env: &Env, project_id: u64, reviewer: Address) -> Option<String> {
+        Self::get_review(env, project_id, reviewer).and_then(|review| {
+            if let Some(cid) = review.ipfs_cid {
+                Some(cid)
+            } else {
+                review.comment_cid
+            }
+        })
+    }
+
+    pub fn get_project_review_cids(env: &Env, project_id: u64) -> Vec<(Address, String)> {
+        let reviewers: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&StorageKey::ProjectReviews(project_id))
+            .unwrap_or_else(|| Vec::new(env));
+
+        let mut cids = Vec::new(env);
+        let len = reviewers.len();
+        for i in 0..len {
+            if let Some(reviewer) = reviewers.get(i) {
+                if let Some(cid) = Self::get_review_cid(env, project_id, reviewer.clone()) {
+                    cids.push_back((reviewer, cid));
+                }
+            }
+        }
+        cids
     }
 
     pub fn get_project_stats(env: &Env, project_id: u64) -> ProjectStats {

--- a/dongle-smartcontract/src/tests/events.rs
+++ b/dongle-smartcontract/src/tests/events.rs
@@ -397,7 +397,10 @@ fn test_review_event_comment_cid_included() {
     let params = make_project_params(&env, &owner, "CommentReview");
     let project_id = client.mock_all_auths().register_project(&params);
 
-    let cid = Some(String::from_str(&env, "QmTestCid123"));
+    let cid = Some(String::from_str(
+        &env,
+        "QmYwAPJzv5CZsnAzt8auVZRnG8X1sC3yRyvCb4s46HoPaz",
+    ));
     client
         .mock_all_auths()
         .add_review(&project_id, &reviewer, &4, &cid);
@@ -407,7 +410,11 @@ fn test_review_event_comment_cid_included() {
         decode_event::<ReviewEventData>(&env, &data)
             .map(|e| {
                 e.project_id == project_id
-                    && e.comment_cid == Some(String::from_str(&env, "QmTestCid123"))
+                    && e.comment_cid
+                        == Some(String::from_str(
+                            &env,
+                            "QmYwAPJzv5CZsnAzt8auVZRnG8X1sC3yRyvCb4s46HoPaz",
+                        ))
             })
             .unwrap_or(false)
     });

--- a/dongle-smartcontract/src/tests/review.rs
+++ b/dongle-smartcontract/src/tests/review.rs
@@ -3,7 +3,7 @@
 use crate::errors::ContractError;
 use crate::tests::fixtures::{create_test_project, setup_contract};
 use crate::DongleContractClient;
-use soroban_sdk::{testutils::Address as _, Address, Env};
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
 
 fn setup(env: &Env) -> (DongleContractClient<'_>, Address) {
     setup_contract(env)
@@ -439,4 +439,68 @@ fn test_re_review_after_delete() {
     assert_eq!(stats.review_count, 1);
     assert_eq!(stats.rating_sum, 400);
     assert_eq!(stats.average_rating, 400);
+}
+
+#[test]
+fn test_submit_review_stores_and_fetches_cid() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+    let project_id = create_test_project(&client, &admin, "ProjectX");
+
+    let reviewer = Address::generate(&env);
+    let cid = String::from_str(&env, "QmYwAPJzv5CZsnAzt8auVZRnG8X1sC3yRyvCb4s46HoPaz");
+
+    client.submit_review(&project_id, &reviewer, &5, &cid);
+
+    let stored = client.get_review(&project_id, &reviewer).unwrap();
+    assert_eq!(
+        stored.ipfs_cid,
+        Some(String::from_str(
+            &env,
+            "QmYwAPJzv5CZsnAzt8auVZRnG8X1sC3yRyvCb4s46HoPaz"
+        ))
+    );
+    assert_eq!(
+        client.get_review_cid(&project_id, &reviewer),
+        Some(String::from_str(
+            &env,
+            "QmYwAPJzv5CZsnAzt8auVZRnG8X1sC3yRyvCb4s46HoPaz"
+        ))
+    );
+}
+
+#[test]
+fn test_submit_review_invalid_cid_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+    let project_id = create_test_project(&client, &admin, "ProjectY");
+
+    let reviewer = Address::generate(&env);
+    let result =
+        client.try_submit_review(&project_id, &reviewer, &4, &String::from_str(&env, "bad"));
+    assert_eq!(result, Err(Ok(ContractError::InvalidProjectData.into())));
+}
+
+#[test]
+fn test_get_project_review_cids_returns_all_entries() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+    let project_id = create_test_project(&client, &admin, "ProjectZ");
+
+    let reviewer_a = Address::generate(&env);
+    let reviewer_b = Address::generate(&env);
+    let cid_a = String::from_str(&env, "QmYwAPJzv5CZsnAzt8auVZRnG8X1sC3yRyvCb4s46HoPaz");
+    let cid_b = String::from_str(
+        &env,
+        "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi",
+    );
+
+    client.submit_review(&project_id, &reviewer_a, &5, &cid_a);
+    client.submit_review(&project_id, &reviewer_b, &3, &cid_b);
+
+    let cids = client.get_project_review_cids(&project_id);
+    assert_eq!(cids.len(), 2);
 }

--- a/dongle-smartcontract/src/utils.rs
+++ b/dongle-smartcontract/src/utils.rs
@@ -42,7 +42,26 @@ impl Utils {
 
     pub fn is_valid_ipfs_cid(cid: &String) -> bool {
         let len = cid.len();
-        (46..=100).contains(&len)
+        if !(46..=128).contains(&len) {
+            return false;
+        }
+
+        extern crate alloc;
+        use alloc::vec;
+        let mut bytes = vec![0u8; len as usize];
+        cid.copy_into_slice(bytes.as_mut_slice());
+
+        // CIDv0: starts with "Qm"
+        if bytes.len() >= 2 {
+            let first = bytes[0];
+            let second = bytes[1];
+            if first == b'Q' && second == b'm' {
+                return true;
+            }
+        }
+
+        // CIDv1 base32 typically starts with 'b' (e.g. bafy...)
+        bytes[0] == b'b'
     }
 
     pub fn is_valid_url(_url: &String) -> bool {


### PR DESCRIPTION
## Summary
- stores review IPFS CID on-chain under the existing `(project_id, reviewer)` review key
- adds CID format validation before persisting review CID data
- exposes new CID-focused methods for frontend retrieval:
  - `submit_review(project_id, reviewer, rating, review_cid)`
  - `get_review_cid(project_id, reviewer)`
  - `get_project_review_cids(project_id)`
- keeps `add_review` / `update_review` backward-compatible while wiring CID into `ipfs_cid`

## Why
Issue #16 requires review content references to be stored as IPFS CIDs on-chain, keyed by project and reviewer, with fetch paths that return CID for frontend IPFS retrieval.

## Validation
- `cargo fmt`
- `cargo test`

## Notes
- Existing generated local change `dongle-smartcontract/target/.rustc_info.json` was not included in this PR.

Closes #16
