### PR TITLE
feat: Add Full Project Metadata Validation (#101)

### DIFF
--- a/dongle-smartcontract/src/errors.rs
+++ b/dongle-smartcontract/src/errors.rs
@@ -51,8 +51,17 @@ pub enum ContractError {
     ProjectDescriptionTooLong = 22,
     /// Project description contains invalid characters
     InvalidProjectDescriptionFormat = 23,
-    /// User has exceeded maximum number of projects allowed
     MaxProjectsExceeded = 24,
+    /// Invalid project website
+    InvalidProjectWebsite = 25,
+    /// Invalid project logo CID
+    InvalidProjectLogoCid = 26,
+    /// Invalid project metadata CID
+    InvalidProjectMetadataCid = 27,
+    /// Project category too long
+    ProjectCategoryTooLong = 28,
+    /// Project website too long
+    ProjectWebsiteTooLong = 29,
 }
 
 // Legacy alias to avoid breaking any code that uses `Error` directly

--- a/dongle-smartcontract/src/project_registry.rs
+++ b/dongle-smartcontract/src/project_registry.rs
@@ -28,8 +28,16 @@ impl ProjectRegistry {
         // Validate description with comprehensive checks
         Utils::validate_description(&params.description)?;
 
-        if params.category.is_empty() {
-            return Err(ContractError::InvalidProjectData);
+        Utils::validate_category_field(&params.category)?;
+
+        if let Some(website) = &params.website {
+            Utils::validate_website(website)?;
+        }
+        if let Some(logo_cid) = &params.logo_cid {
+            Utils::validate_logo_cid(logo_cid)?;
+        }
+        if let Some(metadata_cid) = &params.metadata_cid {
+            Utils::validate_metadata_cid(metadata_cid)?;
         }
 
         // Check if owner has exceeded maximum projects limit
@@ -157,18 +165,25 @@ impl ProjectRegistry {
             project.description = value;
         }
         if let Some(value) = params.category {
-            if value.is_empty() {
-                return Err(ContractError::InvalidProjectCategory);
-            }
+            Utils::validate_category_field(&value)?;
             project.category = value;
         }
         if let Some(value) = params.website {
+            if let Some(ref url) = value {
+                Utils::validate_website(url)?;
+            }
             project.website = value;
         }
         if let Some(value) = params.logo_cid {
+            if let Some(ref cid) = value {
+                Utils::validate_logo_cid(cid)?;
+            }
             project.logo_cid = value;
         }
         if let Some(value) = params.metadata_cid {
+            if let Some(ref cid) = value {
+                Utils::validate_metadata_cid(cid)?;
+            }
             project.metadata_cid = value;
         }
 

--- a/dongle-smartcontract/src/tests/error_handling_tests.rs
+++ b/dongle-smartcontract/src/tests/error_handling_tests.rs
@@ -76,7 +76,7 @@ fn test_register_project_empty_category_returns_error() {
     };
 
     let result = client.try_register_project(&params);
-    assert_eq!(result, Err(Ok(ContractError::InvalidProjectData)));
+    assert_eq!(result, Err(Ok(ContractError::InvalidProjectCategory)));
 }
 
 #[test]
@@ -128,8 +128,8 @@ fn test_register_project_valid_inputs_succeeds() {
         description: String::from_str(&env, "A valid project description"),
         category: String::from_str(&env, "DeFi"),
         website: Some(String::from_str(&env, "https://example.com")),
-        logo_cid: Some(String::from_str(&env, "QmValidCID123")),
-        metadata_cid: Some(String::from_str(&env, "QmValidMetadata456")),
+        logo_cid: Some(String::from_str(&env, "QmYyQSo1c1Ym7orWxLYvCrM2Wu3m39mY5A2zR3EebnXZ7G")),
+        metadata_cid: Some(String::from_str(&env, "QmYyQSo1c1Ym7orWxLYvCrM2Wu3m39mY5A2zR3EebnXZ7G")),
     };
 
     let result = client.try_register_project(&params);
@@ -356,7 +356,7 @@ fn test_no_panic_on_invalid_inputs() {
     let test_cases = [
         ("", "desc", "cat", ContractError::InvalidProjectData),
         ("name", "", "cat", ContractError::InvalidProjectDescription),
-        ("name", "desc", "", ContractError::InvalidProjectData),
+        ("name", "desc", "", ContractError::InvalidProjectCategory),
     ];
 
     for (name, desc, cat, expected_error) in test_cases {
@@ -851,4 +851,136 @@ fn test_update_project_multiple_name_changes() {
         metadata_cid: None,
     };
     client.register_project(&new_params2);
+}
+
+// ── Validation Tests for Website, Category, CIDs ──
+
+#[test]
+fn test_register_project_invalid_website_fails() {
+    let env = Env::default();
+    let (client, _admin) = setup(&env);
+    env.mock_all_auths();
+    let owner = Address::generate(&env);
+
+    let test_cases = [
+        "ftp://example.com",     // invalid scheme
+        "",                      // empty
+        "example.com",           // no scheme
+    ];
+
+    for website in test_cases {
+        let params = ProjectRegistrationParams {
+            owner: owner.clone(),
+            name: String::from_str(&env, "ValidName"),
+            description: String::from_str(&env, "Valid desc"),
+            category: String::from_str(&env, "DeFi"),
+            website: Some(String::from_str(&env, website)),
+            logo_cid: None,
+            metadata_cid: None,
+        };
+        let result = client.try_register_project(&params);
+        assert_eq!(result, Err(Ok(ContractError::InvalidProjectWebsite)));
+    }
+}
+
+#[test]
+fn test_register_project_website_too_long_fails() {
+    let env = Env::default();
+    let (client, _admin) = setup(&env);
+    env.mock_all_auths();
+    let owner = Address::generate(&env);
+
+    extern crate alloc;
+    let mut long_website = alloc::string::String::from("https://");
+    long_website.push_str(&"a".repeat(300));
+
+    let params = ProjectRegistrationParams {
+        owner: owner.clone(),
+        name: String::from_str(&env, "ValidName"),
+        description: String::from_str(&env, "Valid desc"),
+        category: String::from_str(&env, "DeFi"),
+        website: Some(String::from_str(&env, &long_website)),
+        logo_cid: None,
+        metadata_cid: None,
+    };
+    let result = client.try_register_project(&params);
+    assert_eq!(result, Err(Ok(ContractError::ProjectWebsiteTooLong)));
+}
+
+#[test]
+fn test_register_project_invalid_logo_cid_fails() {
+    let env = Env::default();
+    let (client, _admin) = setup(&env);
+    env.mock_all_auths();
+    let owner = Address::generate(&env);
+
+    let test_cases = [
+        "invalid_cid",
+        "",
+        "QmShort",
+    ];
+
+    for cid in test_cases {
+        let params = ProjectRegistrationParams {
+            owner: owner.clone(),
+            name: String::from_str(&env, "ValidName"),
+            description: String::from_str(&env, "Valid desc"),
+            category: String::from_str(&env, "DeFi"),
+            website: None,
+            logo_cid: Some(String::from_str(&env, cid)),
+            metadata_cid: None,
+        };
+        let result = client.try_register_project(&params);
+        assert_eq!(result, Err(Ok(ContractError::InvalidProjectLogoCid)));
+    }
+}
+
+#[test]
+fn test_register_project_invalid_metadata_cid_fails() {
+    let env = Env::default();
+    let (client, _admin) = setup(&env);
+    env.mock_all_auths();
+    let owner = Address::generate(&env);
+
+    let test_cases = [
+        "invalid_cid",
+        "",
+        "QmShort",
+    ];
+
+    for cid in test_cases {
+        let params = ProjectRegistrationParams {
+            owner: owner.clone(),
+            name: String::from_str(&env, "ValidName"),
+            description: String::from_str(&env, "Valid desc"),
+            category: String::from_str(&env, "DeFi"),
+            website: None,
+            logo_cid: None,
+            metadata_cid: Some(String::from_str(&env, cid)),
+        };
+        let result = client.try_register_project(&params);
+        assert_eq!(result, Err(Ok(ContractError::InvalidProjectMetadataCid)));
+    }
+}
+
+#[test]
+fn test_register_project_category_too_long_fails() {
+    let env = Env::default();
+    let (client, _admin) = setup(&env);
+    env.mock_all_auths();
+    let owner = Address::generate(&env);
+
+    let long_category = "a".repeat(100);
+
+    let params = ProjectRegistrationParams {
+        owner: owner.clone(),
+        name: String::from_str(&env, "ValidName"),
+        description: String::from_str(&env, "Valid desc"),
+        category: String::from_str(&env, &long_category),
+        website: None,
+        logo_cid: None,
+        metadata_cid: None,
+    };
+    let result = client.try_register_project(&params);
+    assert_eq!(result, Err(Ok(ContractError::ProjectCategoryTooLong)));
 }

--- a/dongle-smartcontract/src/utils.rs
+++ b/dongle-smartcontract/src/utils.rs
@@ -64,16 +64,60 @@ impl Utils {
         bytes[0] == b'b'
     }
 
-    pub fn is_valid_url(_url: &String) -> bool {
-        true
+    pub fn validate_website(website: &String) -> Result<(), ContractError> {
+        let len = website.len();
+        if len == 0 {
+            return Err(ContractError::InvalidProjectWebsite);
+        }
+        if len > crate::constants::MAX_WEBSITE_LEN as u32 {
+            return Err(ContractError::ProjectWebsiteTooLong);
+        }
+        
+        extern crate alloc;
+        use alloc::string::ToString;
+        let web_str = website.to_string();
+        
+        if !web_str.starts_with("http://") && !web_str.starts_with("https://") {
+            return Err(ContractError::InvalidProjectWebsite);
+        }
+        Ok(())
     }
 
     pub fn sanitize_string(input: &String) -> String {
         input.clone()
     }
 
-    pub fn is_valid_category(_category: &String) -> bool {
-        true
+    pub fn validate_category_field(category: &String) -> Result<(), ContractError> {
+        let len = category.len();
+        if len == 0 {
+            return Err(ContractError::InvalidProjectCategory);
+        }
+        if len > crate::constants::MAX_CATEGORY_LEN as u32 {
+            return Err(ContractError::ProjectCategoryTooLong);
+        }
+        
+        extern crate alloc;
+        use alloc::string::ToString;
+        let cat_str = category.to_string();
+        if cat_str.trim().is_empty() {
+            return Err(ContractError::InvalidProjectCategory);
+        }
+        
+        Ok(())
+    }
+
+    pub fn validate_logo_cid(cid: &String) -> Result<(), ContractError> {
+        if cid.len() == 0 || !Self::is_valid_ipfs_cid(cid) {
+            return Err(ContractError::InvalidProjectLogoCid);
+        }
+        Ok(())
+    }
+
+    pub fn validate_metadata_cid(cid: &String) -> Result<(), ContractError> {
+        if cid.len() == 0 || !Self::is_valid_ipfs_cid(cid) {
+            return Err(ContractError::InvalidProjectMetadataCid);
+        }
+        Ok(())
     }
 
     pub fn validate_pagination(_start_id: u64, limit: u32) -> Result<(), ContractError> {


### PR DESCRIPTION
# Add Full Project Metadata Validation
Closes #101

## Description
This PR addresses issue #101 by implementing strict validation for project metadata fields (`website`, `category`, `logo_cid`, and `metadata_cid`) which were previously accepted without format or length checks. 

This ensures that only well-formed external links and valid IPFS CIDs are recorded on-chain, preventing malformed data entries and improving overall platform data integrity.

## Changes Included
* **New Error Types (`errors.rs`)**: Added `InvalidProjectWebsite`, `InvalidProjectLogoCid`, `InvalidProjectMetadataCid`, `ProjectCategoryTooLong`, and `ProjectWebsiteTooLong` typed errors.
* **Validation Logic (`utils.rs`)**: 
  * Replaced stub functions with concrete implementations for `validate_website` (enforces `http://` or `https://` prefix and length limits), `validate_category_field` (length limits and non-empty), `validate_logo_cid`, and `validate_metadata_cid` (ensures valid IPFS CID length and prefix structure).
* **Smart Contract Integration (`project_registry.rs`)**: 
  * Hooked up the new validation checks in both `register_project` and `update_project` endpoints.
* **Test Suite Updates (`error_handling_tests.rs`)**: 
  * Refactored existing mocked CIDs in the tests to properly adhere to accurate IPFS CID limits (e.g. 46 chars starting with `Qm`).
  * Added extensive validation test coverage to verify that malformed, empty, and out-of-bounds lengths appropriately trigger the newly typed errors without panicking.

## Acceptance Criteria Met
- [x] Invalid website, category, logo CID, and metadata CID are rejected with appropriate typed errors.
- [x] Valid registration and update flows keep passing securely.
- [x] Comprehensive tests added to cover valid, empty, too long, and malformed inputs.


Closes #101 
Closes #114 
Closes #116 
Closes #115 