### PR TITLE
feat(events): restructure event types and add project lifecycle manag…

### DIFF
--- a/dongle-smartcontract/src/errors.rs
+++ b/dongle-smartcontract/src/errors.rs
@@ -90,6 +90,12 @@ pub enum ContractError {
     ReviewAlreadyHidden = 42,
     /// Review is not hidden
     ReviewNotHidden = 43,
+    /// Project is already archived
+    ProjectAlreadyArchived = 44,
+    /// Project is not archived
+    ProjectNotArchived = 45,
+    /// Reports have already been cleared or there are none to clear
+    ReportsAlreadyCleared = 46,
 }
 
 // Legacy alias to avoid breaking any code that uses `Error` directly

--- a/dongle-smartcontract/src/events.rs
+++ b/dongle-smartcontract/src/events.rs
@@ -1,4 +1,4 @@
-use crate::types::{ReviewAction, ReviewEventData, VerificationStatus};
+use crate::types::{ReviewAction, ReviewEventData};
 use soroban_sdk::{contracttype, symbol_short, Address, Env, Map, String, Symbol, Vec};
 
 pub const REVIEW: Symbol = symbol_short!("REVIEW");
@@ -9,6 +9,8 @@ pub enum FeeOperation {
     Verification,
     Registration,
 }
+
+// ── Event structs ─────────────────────────────────────────────────────────────
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -25,6 +27,117 @@ pub struct ProjectRegisteredEvent {
 pub struct ProjectUpdatedEvent {
     pub project_id: u64,
     pub owner: Address,
+    pub timestamp: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProjectArchivedEvent {
+    pub project_id: u64,
+    pub archived_by: Address,
+    pub timestamp: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProjectReactivatedEvent {
+    pub project_id: u64,
+    pub caller: Address,
+    pub timestamp: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProjectOwnershipTransferredEvent {
+    pub project_id: u64,
+    pub caller: Address,
+    pub old_owner: Address,
+    pub new_owner: Address,
+    pub timestamp: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProjectReportedEvent {
+    pub project_id: u64,
+    pub reporter: Address,
+    pub reason_cid: String,
+    pub timestamp: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProjectReportsClearedEvent {
+    pub project_id: u64,
+    pub admin: Address,
+    pub timestamp: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProjectTagsUpdatedEvent {
+    pub project_id: u64,
+    pub owner: Address,
+    pub tags: Option<Vec<String>>,
+    pub timestamp: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProjectSocialLinksUpdatedEvent {
+    pub project_id: u64,
+    pub owner: Address,
+    pub social_links: Option<Map<String, String>>,
+    pub timestamp: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AdminAddedEvent {
+    pub admin: Address,
+    pub timestamp: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AdminRemovedEvent {
+    pub admin: Address,
+    pub timestamp: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReviewReportedEvent {
+    pub project_id: u64,
+    pub reviewer: Address,
+    pub reporter: Address,
+    pub timestamp: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReviewHiddenEvent {
+    pub project_id: u64,
+    pub reviewer: Address,
+    pub admin: Address,
+    pub timestamp: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReviewRestoredEvent {
+    pub project_id: u64,
+    pub reviewer: Address,
+    pub admin: Address,
+    pub timestamp: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReviewDeletedByAdminEvent {
+    pub project_id: u64,
+    pub reviewer: Address,
+    pub admin: Address,
     pub timestamp: u64,
 }
 
@@ -64,6 +177,25 @@ pub struct VerificationRevokedEvent {
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VerificationHistoryClearedEvent {
+    pub project_id: u64,
+    pub admin: Address,
+    pub removed_count: u32,
+    pub retained_count: u32,
+    pub timestamp: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RenewalHistoryClearedEvent {
+    pub project_id: u64,
+    pub admin: Address,
+    pub removed_count: u32,
+    pub timestamp: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct VerificationRenewalRequestedEvent {
     pub project_id: u64,
     pub requester: Address,
@@ -86,75 +218,6 @@ pub struct VerificationRenewalApprovedEvent {
 pub struct VerificationRenewalRejectedEvent {
     pub project_id: u64,
     pub admin: Address,
-    pub timestamp: u64,
-}
-
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ProjectOwnershipTransferredEvent {
-    pub project_id: u64,
-    pub caller: Address,
-    pub old_owner: Address,
-    pub new_owner: Address,
-    pub timestamp: u64,
-}
-
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ProjectArchivedEvent {
-    pub project_id: u64,
-    pub archived_by: Address,
-    pub owner: Address,
-    pub timestamp: u64,
-}
-
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ProjectReactivatedEvent {
-    pub project_id: u64,
-    pub caller: Address,
-    pub archived: bool,
-    pub timestamp: u64,
-}
-
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct AdminAddedEvent {
-    pub admin: Address,
-    pub timestamp: u64,
-}
-
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct AdminRemovedEvent {
-    pub admin: Address,
-    pub timestamp: u64,
-}
-
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ProjectReportedEvent {
-    pub project_id: u64,
-    pub reporter: Address,
-    pub reason_cid: String,
-    pub timestamp: u64,
-}
-
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ProjectTagsUpdatedEvent {
-    pub project_id: u64,
-    pub owner: Address,
-    pub tags: Option<Vec<String>>,
-    pub timestamp: u64,
-}
-
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ProjectSocialLinksUpdatedEvent {
-    pub project_id: u64,
-    pub owner: Address,
-    pub social_links: Option<Map<String, String>>,
     pub timestamp: u64,
 }
 
@@ -199,35 +262,7 @@ pub struct FeeConsumedEvent {
     pub timestamp: u64,
 }
 
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ReviewReportedEvent {
-    pub project_id: u64,
-    pub caller: Address,
-    pub reviewer: Address,
-    pub report_count: u32,
-    pub timestamp: u64,
-}
-
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ReviewHiddenEvent {
-    pub project_id: u64,
-    pub admin: Address,
-    pub reviewer: Address,
-    pub hidden: bool,
-    pub timestamp: u64,
-}
-
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ReviewRestoredEvent {
-    pub project_id: u64,
-    pub admin: Address,
-    pub reviewer: Address,
-    pub hidden: bool,
-    pub timestamp: u64,
-}
+// ── Publish helpers ───────────────────────────────────────────────────────────
 
 #[allow(clippy::too_many_arguments)]
 pub fn publish_review_event(
@@ -317,13 +352,10 @@ pub fn publish_project_archived_event(env: &Env, project_id: u64, archived_by: A
     );
 }
 
-// ── Fee events ────────────────────────────────────────────────────────────────
-
 pub fn publish_project_reactivated_event(env: &Env, project_id: u64, caller: Address) {
     let event_data = ProjectReactivatedEvent {
         project_id,
         caller,
-        archived: false,
         timestamp: env.ledger().timestamp(),
     };
     env.events().publish(
@@ -336,66 +368,214 @@ pub fn publish_project_reactivated_event(env: &Env, project_id: u64, caller: Add
     );
 }
 
-pub fn publish_fee_paid_event(
+pub fn publish_project_reported_event(
     env: &Env,
     project_id: u64,
-    payer: Address,
-    token: Option<Address>,
-    operation: FeeOperation,
-    amount: u128,
+    reporter: Address,
+    reason_cid: String,
 ) {
-    let event_data = FeePaidEvent {
+    let event_data = ProjectReportedEvent {
         project_id,
-        payer,
-        token,
-        operation,
-        amount,
+        reporter,
+        reason_cid,
         timestamp: env.ledger().timestamp(),
     };
     env.events().publish(
-        (symbol_short!("FEE"), symbol_short!("PAID"), project_id),
+        (
+            symbol_short!("PROJECT"),
+            symbol_short!("REPORTED"),
+            project_id,
+        ),
         event_data,
     );
 }
 
-pub fn publish_fee_consumed_event(
+pub fn publish_project_reports_cleared_event(env: &Env, project_id: u64, admin: Address) {
+    let event_data = ProjectReportsClearedEvent {
+        project_id,
+        admin,
+        timestamp: env.ledger().timestamp(),
+    };
+    env.events().publish(
+        (
+            symbol_short!("PROJECT"),
+            symbol_short!("RPCLEARED"),
+            project_id,
+        ),
+        event_data,
+    );
+}
+
+pub fn publish_project_tags_updated_event(
+    env: &Env,
+    project_id: u64,
+    owner: Address,
+    tags: Option<Vec<String>>,
+) {
+    let event_data = ProjectTagsUpdatedEvent {
+        project_id,
+        owner,
+        tags,
+        timestamp: env.ledger().timestamp(),
+    };
+    env.events().publish(
+        (symbol_short!("PROJECT"), symbol_short!("TAGS"), project_id),
+        event_data,
+    );
+}
+
+pub fn publish_project_social_links_updated_event(
+    env: &Env,
+    project_id: u64,
+    owner: Address,
+    social_links: Option<Map<String, String>>,
+) {
+    let event_data = ProjectSocialLinksUpdatedEvent {
+        project_id,
+        owner,
+        social_links,
+        timestamp: env.ledger().timestamp(),
+    };
+    env.events().publish(
+        (
+            symbol_short!("PROJECT"),
+            symbol_short!("SOCIAL"),
+            project_id,
+        ),
+        event_data,
+    );
+}
+
+pub fn publish_ownership_transferred_event(
     env: &Env,
     project_id: u64,
     caller: Address,
-    operation: FeeOperation,
-    amount: u128,
+    old_owner: Address,
+    new_owner: Address,
 ) {
-    let event_data = FeeConsumedEvent {
+    let event_data = ProjectOwnershipTransferredEvent {
         project_id,
         caller,
-        operation,
-        amount,
+        old_owner,
+        new_owner,
         timestamp: env.ledger().timestamp(),
     };
     env.events().publish(
-        (symbol_short!("FEE"), symbol_short!("CONSUMED"), project_id),
+        (
+            symbol_short!("PROJECT"),
+            symbol_short!("TRANSFER"),
+            project_id,
+        ),
         event_data,
     );
 }
 
-pub fn publish_fee_set_event(
-    env: &Env,
-    admin: Address,
-    token: Option<Address>,
-    verification_fee: u128,
-    registration_fee: u128,
-    treasury: Address,
-) {
-    let event_data = FeeSetEvent {
+pub fn publish_admin_added_event(env: &Env, admin: Address) {
+    let event_data = AdminAddedEvent {
         admin,
-        token,
-        verification_fee,
-        registration_fee,
-        treasury,
         timestamp: env.ledger().timestamp(),
     };
     env.events()
-        .publish((symbol_short!("CONFIG"), symbol_short!("FEE")), event_data);
+        .publish((symbol_short!("ADMIN"), symbol_short!("ADDED")), event_data);
+}
+
+pub fn publish_admin_removed_event(env: &Env, admin: Address) {
+    let event_data = AdminRemovedEvent {
+        admin,
+        timestamp: env.ledger().timestamp(),
+    };
+    env.events().publish(
+        (symbol_short!("ADMIN"), symbol_short!("REMOVED")),
+        event_data,
+    );
+}
+
+pub fn publish_review_reported_event(
+    env: &Env,
+    project_id: u64,
+    reviewer: Address,
+    reporter: Address,
+) {
+    let event_data = ReviewReportedEvent {
+        project_id,
+        reviewer,
+        reporter,
+        timestamp: env.ledger().timestamp(),
+    };
+    env.events().publish(
+        (
+            symbol_short!("REVIEW"),
+            symbol_short!("REPORTED"),
+            project_id,
+        ),
+        event_data,
+    );
+}
+
+pub fn publish_review_hidden_event(
+    env: &Env,
+    project_id: u64,
+    reviewer: Address,
+    admin: Address,
+) {
+    let event_data = ReviewHiddenEvent {
+        project_id,
+        reviewer,
+        admin,
+        timestamp: env.ledger().timestamp(),
+    };
+    env.events().publish(
+        (
+            symbol_short!("REVIEW"),
+            symbol_short!("HIDDEN"),
+            project_id,
+        ),
+        event_data,
+    );
+}
+
+pub fn publish_review_restored_event(
+    env: &Env,
+    project_id: u64,
+    reviewer: Address,
+    admin: Address,
+) {
+    let event_data = ReviewRestoredEvent {
+        project_id,
+        reviewer,
+        admin,
+        timestamp: env.ledger().timestamp(),
+    };
+    env.events().publish(
+        (
+            symbol_short!("REVIEW"),
+            symbol_short!("RESTORED"),
+            project_id,
+        ),
+        event_data,
+    );
+}
+
+pub fn publish_review_deleted_by_admin_event(
+    env: &Env,
+    project_id: u64,
+    reviewer: Address,
+    admin: Address,
+) {
+    let event_data = ReviewDeletedByAdminEvent {
+        project_id,
+        reviewer,
+        admin,
+        timestamp: env.ledger().timestamp(),
+    };
+    env.events().publish(
+        (
+            symbol_short!("REVIEW"),
+            symbol_short!("ADMINDEL"),
+            project_id,
+        ),
+        event_data,
+    );
 }
 
 pub fn publish_verification_requested_event(
@@ -462,6 +642,52 @@ pub fn publish_verification_revoked_event(
     );
 }
 
+pub fn publish_verification_history_cleared_event(
+    env: &Env,
+    project_id: u64,
+    admin: Address,
+    removed_count: u32,
+    retained_count: u32,
+) {
+    let event_data = VerificationHistoryClearedEvent {
+        project_id,
+        admin,
+        removed_count,
+        retained_count,
+        timestamp: env.ledger().timestamp(),
+    };
+    env.events().publish(
+        (
+            symbol_short!("VERIFY"),
+            symbol_short!("HISTCLR"),
+            project_id,
+        ),
+        event_data,
+    );
+}
+
+pub fn publish_renewal_history_cleared_event(
+    env: &Env,
+    project_id: u64,
+    admin: Address,
+    removed_count: u32,
+) {
+    let event_data = RenewalHistoryClearedEvent {
+        project_id,
+        admin,
+        removed_count,
+        timestamp: env.ledger().timestamp(),
+    };
+    env.events().publish(
+        (
+            symbol_short!("RENEW"),
+            symbol_short!("HISTCLR"),
+            project_id,
+        ),
+        event_data,
+    );
+}
+
 pub fn publish_verification_renewal_requested_event(
     env: &Env,
     project_id: u64,
@@ -500,11 +726,7 @@ pub fn publish_verification_renewal_approved_event(
     );
 }
 
-pub fn publish_verification_renewal_rejected_event(
-    env: &Env,
-    project_id: u64,
-    admin: Address,
-) {
+pub fn publish_verification_renewal_rejected_event(env: &Env, project_id: u64, admin: Address) {
     let event_data = VerificationRenewalRejectedEvent {
         project_id,
         admin,
@@ -516,110 +738,66 @@ pub fn publish_verification_renewal_rejected_event(
     );
 }
 
-pub fn publish_ownership_transferred_event(
+pub fn publish_fee_paid_event(
+    env: &Env,
+    project_id: u64,
+    payer: Address,
+    token: Option<Address>,
+    operation: FeeOperation,
+    amount: u128,
+) {
+    let event_data = FeePaidEvent {
+        project_id,
+        payer,
+        token,
+        operation,
+        amount,
+        timestamp: env.ledger().timestamp(),
+    };
+    env.events().publish(
+        (symbol_short!("FEE"), symbol_short!("PAID"), project_id),
+        event_data,
+    );
+}
+
+pub fn publish_fee_consumed_event(
     env: &Env,
     project_id: u64,
     caller: Address,
-    old_owner: Address,
-    new_owner: Address,
+    operation: FeeOperation,
+    amount: u128,
 ) {
-    let event_data = ProjectOwnershipTransferredEvent {
+    let event_data = FeeConsumedEvent {
         project_id,
         caller,
-        old_owner,
-        new_owner,
+        operation,
+        amount,
         timestamp: env.ledger().timestamp(),
     };
     env.events().publish(
-        (
-            symbol_short!("PROJECT"),
-            symbol_short!("TRANSFER"),
-            project_id,
-        ),
+        (symbol_short!("FEE"), symbol_short!("CONSUMED"), project_id),
         event_data,
     );
 }
 
-pub fn publish_admin_added_event(env: &Env, admin: Address) {
-    let event_data = AdminAddedEvent {
+pub fn publish_fee_set_event(
+    env: &Env,
+    admin: Address,
+    token: Option<Address>,
+    verification_fee: u128,
+    registration_fee: u128,
+    treasury: Address,
+) {
+    let event_data = FeeSetEvent {
         admin,
+        token,
+        verification_fee,
+        registration_fee,
+        treasury,
         timestamp: env.ledger().timestamp(),
     };
     env.events()
-        .publish((symbol_short!("ADMIN"), symbol_short!("ADDED")), event_data);
-}
-
-pub fn publish_admin_removed_event(env: &Env, admin: Address) {
-    let event_data = AdminRemovedEvent {
-        admin,
-        timestamp: env.ledger().timestamp(),
-    };
-    env.events().publish(
-        (symbol_short!("ADMIN"), symbol_short!("REMOVED")),
-        event_data,
-    );
-}
-
-pub fn publish_project_reported_event(
-    env: &Env,
-    project_id: u64,
-    reporter: Address,
-    reason_cid: String,
-) {
-    let event_data = ProjectReportedEvent {
-        project_id,
-        reporter,
-        reason_cid,
-        timestamp: env.ledger().timestamp(),
-    };
-    env.events().publish(
-        (
-            symbol_short!("PROJECT"),
-            symbol_short!("REPORTED"),
-            project_id,
-        ),
-        event_data,
-    );
-}
-
-pub fn publish_project_tags_updated_event(
-    env: &Env,
-    project_id: u64,
-    owner: Address,
-    tags: Option<Vec<String>>,
-) {
-    let event_data = ProjectTagsUpdatedEvent {
-        project_id,
-        owner,
-        tags,
-        timestamp: env.ledger().timestamp(),
-    };
-    env.events().publish(
-        (symbol_short!("PROJECT"), symbol_short!("TAGS"), project_id),
-        event_data,
-    );
-}
-
-pub fn publish_project_social_links_updated_event(
-    env: &Env,
-    project_id: u64,
-    owner: Address,
-    social_links: Option<Map<String, String>>,
-) {
-    let event_data = ProjectSocialLinksUpdatedEvent {
-        project_id,
-        owner,
-        social_links,
-        timestamp: env.ledger().timestamp(),
-    };
-    env.events().publish(
-        (
-            symbol_short!("PROJECT"),
-            symbol_short!("SOCIAL"),
-            project_id,
-        ),
-        event_data,
-    );
+        .publish((symbol_short!("CONFIG"), symbol_short!("FEE")), event_data);
 }
 
 pub fn publish_min_project_age_set_event(
@@ -636,72 +814,6 @@ pub fn publish_min_project_age_set_event(
     };
     env.events().publish(
         (symbol_short!("CONFIG"), symbol_short!("MIN_AGE")),
-        event_data,
-    );
-}
-
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ReviewReportedEvent {
-    pub project_id: u64,
-    pub reviewer: Address,
-    pub reporter: Address,
-    pub timestamp: u64,
-}
-
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ReviewHiddenEvent {
-    pub project_id: u64,
-    pub reviewer: Address,
-    pub admin: Address,
-    pub timestamp: u64,
-}
-
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ReviewRestoredEvent {
-    pub project_id: u64,
-    pub reviewer: Address,
-    pub admin: Address,
-    pub timestamp: u64,
-}
-
-pub fn publish_review_reported_event(env: &Env, project_id: u64, reviewer: Address, reporter: Address) {
-    let event_data = ReviewReportedEvent {
-        project_id,
-        reviewer,
-        reporter,
-        timestamp: env.ledger().timestamp(),
-    };
-    env.events().publish(
-        (symbol_short!(\"REVIEW\"), symbol_short!(\"REPORTED\"), project_id),
-        event_data,
-    );
-}
-
-pub fn publish_review_hidden_event(env: &Env, project_id: u64, reviewer: Address, admin: Address) {
-    let event_data = ReviewHiddenEvent {
-        project_id,
-        reviewer,
-        admin,
-        timestamp: env.ledger().timestamp(),
-    };
-    env.events().publish(
-        (symbol_short!(\"REVIEW\"), symbol_short!(\"HIDDEN\"), project_id),
-        event_data,
-    );
-}
-
-pub fn publish_review_restored_event(env: &Env, project_id: u64, reviewer: Address, admin: Address) {
-    let event_data = ReviewRestoredEvent {
-        project_id,
-        reviewer,
-        admin,
-        timestamp: env.ledger().timestamp(),
-    };
-    env.events().publish(
-        (symbol_short!(\"REVIEW\"), symbol_short!(\"RESTORED\"), project_id),
         event_data,
     );
 }

--- a/dongle-smartcontract/src/lib.rs
+++ b/dongle-smartcontract/src/lib.rs
@@ -307,6 +307,16 @@ impl DongleContract {
         ReviewRegistry::restore_review(&env, project_id, reviewer, admin)
     }
 
+    /// Admin hard-delete a review permanently (admin-only).
+    pub fn admin_delete_review(
+        env: Env,
+        project_id: u64,
+        reviewer: Address,
+        admin: Address,
+    ) -> Result<(), ContractError> {
+        ReviewRegistry::admin_delete_review(&env, project_id, reviewer, admin)
+    }
+
     // --- Verification Registry ---
 
     pub fn request_verification(
@@ -393,6 +403,27 @@ impl DongleContract {
 
     pub fn is_verification_expired(env: Env, project_id: u64) -> Result<bool, ContractError> {
         VerificationRegistry::is_verification_expired(&env, project_id)
+    }
+
+    /// Admin: prune verification history, keeping the most recent `keep_count` records.
+    /// Returns the number of records removed.
+    pub fn clear_verification_history(
+        env: Env,
+        project_id: u64,
+        admin: Address,
+        keep_count: u32,
+    ) -> Result<u32, ContractError> {
+        VerificationRegistry::clear_verification_history(&env, project_id, &admin, keep_count)
+    }
+
+    /// Admin: clear all renewal history records for a project.
+    /// Returns the number of records removed.
+    pub fn clear_renewal_history(
+        env: Env,
+        project_id: u64,
+        admin: Address,
+    ) -> Result<u32, ContractError> {
+        VerificationRegistry::clear_renewal_history(&env, project_id, &admin)
     }
 
     // --- Fee Manager ---
@@ -503,6 +534,15 @@ impl DongleContract {
     /// Check if a user has already reported a project - Issue #127
     pub fn has_user_reported(env: Env, project_id: u64, reporter: Address) -> bool {
         ReportRegistry::has_user_reported(&env, project_id, &reporter)
+    }
+
+    /// Admin: clear all reports for a project (admin-only).
+    pub fn clear_project_reports(
+        env: Env,
+        project_id: u64,
+        admin: Address,
+    ) -> Result<(), ContractError> {
+        ReportRegistry::clear_project_reports(&env, project_id, &admin)
     }
 
     /// List projects by tag - Issue #125

--- a/dongle-smartcontract/src/project_registry.rs
+++ b/dongle-smartcontract/src/project_registry.rs
@@ -2,7 +2,6 @@ use crate::constants::MAX_PROJECTS_PER_USER;
 use crate::errors::ContractError;
 use crate::events::{
     publish_ownership_transferred_event, publish_project_archived_event,
-    publish_project_registered_event, publish_project_updated_event,
     publish_project_reactivated_event, publish_project_registered_event,
     publish_project_updated_event,
 };
@@ -110,10 +109,9 @@ impl ProjectRegistry {
             logo_cid: params.logo_cid,
             metadata_cid: params.metadata_cid,
             verification_status: VerificationStatus::Unverified,
-            is_archived: false,
+            archived: false,
             created_at: now,
             updated_at: now,
-            archived: false,
             tags: params.tags.clone(),
             social_links: params.social_links.clone(),
         };
@@ -594,14 +592,11 @@ impl ProjectRegistry {
         }
 
         // start_id is 1-based (projects are stored with IDs starting at 1).
-        // Clamp to valid range.
         let first = if start_id == 0 { 1u64 } else { start_id };
         if first > count {
             return projects;
         }
 
-        let mut collected: u32 = 0;
-        for id in first..=count {
         let end = core::cmp::min(
             first.saturating_add(effective_limit as u64),
             count.saturating_add(1),
@@ -613,7 +608,6 @@ impl ProjectRegistry {
                 break;
             }
             if let Some(project) = Self::get_project(env, id) {
-                if !project.is_archived {
                 if !project.archived {
                     projects.push_back(project);
                     collected += 1;
@@ -647,8 +641,6 @@ impl ProjectRegistry {
             return projects;
         }
 
-        let mut collected: u32 = 0;
-        for i in start_id..len {
         let end = core::cmp::min(start_id.saturating_add(effective_limit), len);
 
         let mut collected: u32 = 0;
@@ -658,7 +650,6 @@ impl ProjectRegistry {
             }
             if let Some(id) = category_projects.get(i) {
                 if let Some(project) = Self::get_project(env, id) {
-                    if !project.is_archived {
                     if !project.archived {
                         projects.push_back(project);
                         collected += 1;
@@ -796,61 +787,7 @@ impl ProjectRegistry {
         Ok(())
     }
 
-    pub fn archive_project(
-        env: &Env,
-        project_id: u64,
-        caller: Address,
-    ) -> Result<(), ContractError> {
-        let mut project =
-            Self::get_project(env, project_id).ok_or(ContractError::ProjectNotFound)?;
-
-        caller.require_auth();
-        if project.owner != caller {
-            return Err(ContractError::Unauthorized);
-        }
-        if project.archived {
-            return Err(ContractError::ProjectAlreadyArchived);
-        }
-
-        project.archived = true;
-        project.updated_at = env.ledger().timestamp();
-        env.storage()
-            .persistent()
-            .set(&StorageKey::Project(project_id), &project);
-
-        StorageManager::extend_project_ttl(env, project_id);
-        publish_project_archived_event(env, project_id, caller);
-        Ok(())
-    }
-
-    pub fn reactivate_project(
-        env: &Env,
-        project_id: u64,
-        caller: Address,
-    ) -> Result<(), ContractError> {
-        let mut project =
-            Self::get_project(env, project_id).ok_or(ContractError::ProjectNotFound)?;
-
-        caller.require_auth();
-        if project.owner != caller {
-            return Err(ContractError::Unauthorized);
-        }
-        if !project.archived {
-            return Err(ContractError::ProjectNotArchived);
-        }
-
-        project.archived = false;
-        project.updated_at = env.ledger().timestamp();
-        env.storage()
-            .persistent()
-            .set(&StorageKey::Project(project_id), &project);
-
-        StorageManager::extend_project_ttl(env, project_id);
-        publish_project_reactivated_event(env, project_id, caller);
-        Ok(())
-    }
-
-    /// Archive a project. The owner can archive their own project; admins can force-archive any project.
+    /// Archive a project. The owner or any admin can archive a project.
     pub fn archive_project(
         env: &Env,
         project_id: u64,
@@ -868,16 +805,54 @@ impl ProjectRegistry {
             return Err(ContractError::Unauthorized);
         }
 
-        project.is_archived = true;
+        if project.archived {
+            return Err(ContractError::ProjectAlreadyArchived);
+        }
+
+        project.archived = true;
         project.updated_at = env.ledger().timestamp();
         env.storage()
             .persistent()
             .set(&StorageKey::Project(project_id), &project);
 
         StorageManager::extend_project_ttl(env, project_id);
-
         publish_project_archived_event(env, project_id, caller);
         Ok(())
+    }
+
+    /// Reactivate an archived project. The owner or any admin can reactivate.
+    pub fn reactivate_project(
+        env: &Env,
+        project_id: u64,
+        caller: Address,
+    ) -> Result<(), ContractError> {
+        let mut project =
+            Self::get_project(env, project_id).ok_or(ContractError::ProjectNotFound)?;
+
+        caller.require_auth();
+
+        let is_owner = project.owner == caller;
+        let is_admin = crate::admin_manager::AdminManager::is_admin(env, &caller);
+
+        if !is_owner && !is_admin {
+            return Err(ContractError::Unauthorized);
+        }
+
+        if !project.archived {
+            return Err(ContractError::ProjectNotArchived);
+        }
+
+        project.archived = false;
+        project.updated_at = env.ledger().timestamp();
+        env.storage()
+            .persistent()
+            .set(&StorageKey::Project(project_id), &project);
+
+        StorageManager::extend_project_ttl(env, project_id);
+        publish_project_reactivated_event(env, project_id, caller);
+        Ok(())
+    }
+
     /// List projects by tag - Issue #125
     pub fn list_projects_by_tag(env: &Env, tag: String, start_id: u32, limit: u32) -> Vec<Project> {
         let effective_limit = if limit == 0 || limit > MAX_PAGE_LIMIT {
@@ -898,16 +873,17 @@ impl ProjectRegistry {
         }
 
         let mut collected: u32 = 0;
-        let mut current_id: u32 = start_id;
 
-        // Iterate through projects starting from start_id
+        // Iterate through all projects; start_id is a 0-based offset into the project ID space.
         for id in (start_id as u64 + 1)..=count {
             if collected >= effective_limit {
                 break;
             }
 
             if let Some(project) = Self::get_project(env, id) {
-                // Check if project has the specified tag
+                if project.archived {
+                    continue;
+                }
                 if let Some(tags) = &project.tags {
                     for project_tag in tags.iter() {
                         if project_tag == tag {

--- a/dongle-smartcontract/src/report_registry.rs
+++ b/dongle-smartcontract/src/report_registry.rs
@@ -96,4 +96,56 @@ impl ReportRegistry {
             .persistent()
             .has(&StorageKey::UserReport(project_id, reporter.clone()))
     }
+
+    /// Clear all reports for a project (admin-only).
+    ///
+    /// Removes the reports list, the report count, and all per-user dedup keys
+    /// so reporters can file new reports after the slate is cleaned.
+    /// Returns `ReportsAlreadyCleared` if there are no reports to clear.
+    pub fn clear_project_reports(
+        env: &Env,
+        project_id: u64,
+        admin: &Address,
+    ) -> Result<(), ContractError> {
+        // Auth: admin only
+        if !crate::admin_manager::AdminManager::is_admin(env, admin) {
+            return Err(ContractError::AdminOnly);
+        }
+
+        // Project must exist
+        crate::project_registry::ProjectRegistry::get_project(env, project_id)
+            .ok_or(ContractError::ProjectNotFound)?;
+
+        let count = Self::get_project_report_count(env, project_id);
+        if count == 0 {
+            return Err(ContractError::ReportsAlreadyCleared);
+        }
+
+        // Gather existing reports to remove individual UserReport dedup keys
+        let reports: Vec<crate::types::ProjectReport> = env
+            .storage()
+            .persistent()
+            .get(&StorageKey::ProjectReports(project_id))
+            .unwrap_or_else(|| Vec::new(env));
+
+        // Remove per-reporter dedup keys so they can report again
+        for i in 0..reports.len() {
+            if let Some(report) = reports.get(i) {
+                env.storage()
+                    .persistent()
+                    .remove(&StorageKey::UserReport(project_id, report.reporter.clone()));
+            }
+        }
+
+        // Remove the reports list and count
+        env.storage()
+            .persistent()
+            .remove(&StorageKey::ProjectReports(project_id));
+        env.storage()
+            .persistent()
+            .remove(&StorageKey::ProjectReportCount(project_id));
+
+        crate::events::publish_project_reports_cleared_event(env, project_id, admin.clone());
+        Ok(())
+    }
 }

--- a/dongle-smartcontract/src/review_registry.rs
+++ b/dongle-smartcontract/src/review_registry.rs
@@ -321,6 +321,18 @@ impl ReviewRegistry {
             &new_project_reviews,
         );
 
+        // Clean up any ReviewReport dedup keys for this review so that
+        // the storage doesn't accumulate dangling report entries after deletion.
+        // We iterate up to the stored report_count to remove known reporter keys.
+        // Since we don't store the list of reporters separately, we just remove
+        // the review's own report_count worth of possible keys by clearing the
+        // report_count marker — the actual per-reporter keys will expire via TTL.
+        // For immediate consistency we remove the count itself from the review record
+        // (already done by removing the review_key above).
+        // No separate cleanup needed beyond removing the review record itself,
+        // as ReviewReport keys are dedup guards keyed by (project_id, reviewer, reporter)
+        // and those will become orphaned but harmless once the review is gone.
+
         let now = env.ledger().timestamp();
         publish_review_event(
             env,
@@ -332,6 +344,107 @@ impl ReviewRegistry {
             existing.created_at,
             now,
         );
+        Ok(())
+    }
+
+    /// Admin hard-delete a review. Admins can permanently remove any review,
+    /// updating stats and indexes just like a reviewer-initiated delete.
+    pub fn admin_delete_review(
+        env: &Env,
+        project_id: u64,
+        reviewer: Address,
+        admin: Address,
+    ) -> Result<(), ContractError> {
+        // Validation phase
+        admin.require_auth();
+
+        // Admin check
+        if !crate::admin_manager::AdminManager::is_admin(env, &admin) {
+            return Err(ContractError::AdminOnly);
+        }
+
+        // Check if project exists
+        if ProjectRegistry::get_project(env, project_id).is_none() {
+            return Err(ContractError::ProjectNotFound);
+        }
+
+        let review_key = StorageKey::Review(project_id, reviewer.clone());
+        let existing: Review = env
+            .storage()
+            .persistent()
+            .get(&review_key)
+            .ok_or(ContractError::ReviewNotFound)?;
+
+        // Mutation phase — same index/stats cleanup as delete_review
+        let stats: ProjectStats = env
+            .storage()
+            .persistent()
+            .get(&StorageKey::ProjectStats(project_id))
+            .unwrap_or(ProjectStats {
+                rating_sum: 0,
+                review_count: 0,
+                average_rating: 0,
+            });
+        let user_reviews: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&StorageKey::UserReviews(reviewer.clone()))
+            .unwrap_or_else(|| Vec::new(env));
+        let project_reviews: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&StorageKey::ProjectReviews(project_id))
+            .unwrap_or_else(|| Vec::new(env));
+
+        // Recalculate stats — exclude hidden reviews that were already excluded
+        let (new_sum, new_count, new_avg) = if stats.review_count > 0 && !existing.hidden {
+            RatingCalculator::remove_rating(stats.rating_sum, stats.review_count, existing.rating)
+        } else {
+            (stats.rating_sum, stats.review_count, stats.average_rating)
+        };
+
+        // Rebuild user reviews list without this project
+        let mut new_user_reviews = Vec::new(env);
+        for i in 0..user_reviews.len() {
+            if let Some(id) = user_reviews.get(i) {
+                if id != project_id {
+                    new_user_reviews.push_back(id);
+                }
+            }
+        }
+
+        // Rebuild project reviews list without this reviewer
+        let mut new_project_reviews = Vec::new(env);
+        for i in 0..project_reviews.len() {
+            if let Some(addr) = project_reviews.get(i) {
+                if addr != reviewer {
+                    new_project_reviews.push_back(addr);
+                }
+            }
+        }
+
+        // Apply all mutations
+        env.storage().persistent().remove(&review_key);
+        env.storage().persistent().set(
+            &StorageKey::ProjectStats(project_id),
+            &ProjectStats {
+                rating_sum: new_sum,
+                review_count: new_count,
+                average_rating: new_avg,
+            },
+        );
+        env.storage().persistent().set(
+            &StorageKey::UserReviews(reviewer.clone()),
+            &new_user_reviews,
+        );
+        env.storage().persistent().set(
+            &StorageKey::ProjectReviews(project_id),
+            &new_project_reviews,
+        );
+
+        let now = env.ledger().timestamp();
+        crate::events::publish_review_deleted_by_admin_event(env, project_id, reviewer, admin);
+        let _ = now; // timestamp captured for potential future use
         Ok(())
     }
 

--- a/dongle-smartcontract/src/tests/cleanup.rs
+++ b/dongle-smartcontract/src/tests/cleanup.rs
@@ -1,0 +1,650 @@
+//! Tests for stale-record cleanup functions:
+//! - admin_delete_review
+//! - clear_project_reports
+//! - clear_verification_history
+//! - clear_renewal_history
+//! - admin reactivate_project
+//! - index consistency after cleanup
+
+use crate::errors::ContractError;
+use crate::tests::fixtures::{create_test_project, setup_contract};
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+fn valid_cid(env: &Env) -> String {
+    String::from_str(env, "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi")
+}
+
+fn setup(env: &Env) -> (crate::DongleContractClient<'_>, Address) {
+    setup_contract(env)
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// admin_delete_review
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_admin_delete_review_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+    let project_id = create_test_project(&client, &admin, "ProjectA");
+
+    let reviewer = Address::generate(&env);
+    client.add_review(&project_id, &reviewer, &5, &None);
+
+    // Sanity: review exists, stats reflect it
+    let stats_before = client.get_project_stats(&project_id);
+    assert_eq!(stats_before.review_count, 1);
+
+    client.admin_delete_review(&project_id, &reviewer, &admin);
+
+    // Review is gone
+    assert!(client.get_review(&project_id, &reviewer).is_none());
+
+    // Stats recalculated — review_count back to 0
+    let stats_after = client.get_project_stats(&project_id);
+    assert_eq!(stats_after.review_count, 0);
+    assert_eq!(stats_after.rating_sum, 0);
+}
+
+#[test]
+fn test_admin_delete_review_updates_project_reviews_index() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+    let project_id = create_test_project(&client, &admin, "ProjectB");
+
+    let r1 = Address::generate(&env);
+    let r2 = Address::generate(&env);
+    client.add_review(&project_id, &r1, &5, &None);
+    client.add_review(&project_id, &r2, &4, &None);
+
+    client.admin_delete_review(&project_id, &r1, &admin);
+
+    // r1 gone, r2 still present
+    assert!(client.get_review(&project_id, &r1).is_none());
+    assert!(client.get_review(&project_id, &r2).is_some());
+
+    // list_reviews only returns r2
+    let reviews = client.list_reviews(&project_id, &0, &100);
+    assert_eq!(reviews.len(), 1);
+    assert_eq!(reviews.get(0).unwrap().reviewer, r2);
+}
+
+#[test]
+fn test_admin_delete_review_updates_user_reviews_index() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+
+    // Two projects; reviewer reviewed both
+    let pid1 = create_test_project(&client, &admin, "ProjectC");
+    let pid2 = create_test_project(&client, &admin, "ProjectD");
+
+    let reviewer = Address::generate(&env);
+    client.add_review(&pid1, &reviewer, &5, &None);
+    client.add_review(&pid2, &reviewer, &3, &None);
+
+    // Admin deletes review on project 1 only
+    client.admin_delete_review(&pid1, &reviewer, &admin);
+
+    // Review on project 1 gone; project 2 review still intact
+    assert!(client.get_review(&pid1, &reviewer).is_none());
+    let r2 = client.get_review(&pid2, &reviewer);
+    assert!(r2.is_some());
+    assert_eq!(r2.unwrap().rating, 3);
+}
+
+#[test]
+fn test_admin_delete_hidden_review_keeps_stats_consistent() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+    let project_id = create_test_project(&client, &admin, "ProjectE");
+
+    let reviewer = Address::generate(&env);
+    client.add_review(&project_id, &reviewer, &5, &None);
+
+    // Hide the review first (stats already decremented)
+    client.hide_review(&project_id, &reviewer, &admin);
+    let stats_hidden = client.get_project_stats(&project_id);
+    assert_eq!(stats_hidden.review_count, 0);
+
+    // Admin delete — must not double-decrement
+    client.admin_delete_review(&project_id, &reviewer, &admin);
+    let stats_after = client.get_project_stats(&project_id);
+    assert_eq!(stats_after.review_count, 0);
+    assert_eq!(stats_after.rating_sum, 0);
+}
+
+#[test]
+fn test_admin_delete_review_non_admin_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+    let project_id = create_test_project(&client, &admin, "ProjectF");
+
+    let reviewer = Address::generate(&env);
+    let non_admin = Address::generate(&env);
+    client.add_review(&project_id, &reviewer, &5, &None);
+
+    let result = client.try_admin_delete_review(&project_id, &reviewer, &non_admin);
+    assert_eq!(result, Err(Ok(ContractError::AdminOnly)));
+    // Review still exists
+    assert!(client.get_review(&project_id, &reviewer).is_some());
+}
+
+#[test]
+fn test_admin_delete_review_missing_review_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+    let project_id = create_test_project(&client, &admin, "ProjectG");
+
+    let ghost_reviewer = Address::generate(&env);
+    let result = client.try_admin_delete_review(&project_id, &ghost_reviewer, &admin);
+    assert_eq!(result, Err(Ok(ContractError::ReviewNotFound)));
+}
+
+#[test]
+fn test_admin_delete_review_missing_project_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+
+    let reviewer = Address::generate(&env);
+    let result = client.try_admin_delete_review(&999u64, &reviewer, &admin);
+    assert_eq!(result, Err(Ok(ContractError::ProjectNotFound)));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// clear_project_reports
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_clear_project_reports_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+    let project_id = create_test_project(&client, &admin, "ProjectH");
+
+    let reporter1 = Address::generate(&env);
+    let reporter2 = Address::generate(&env);
+    client.report_project(&project_id, &reporter1, &valid_cid(&env));
+    client.report_project(&project_id, &reporter2, &valid_cid(&env));
+
+    assert_eq!(client.get_project_report_count(&project_id), 2);
+
+    client.clear_project_reports(&project_id, &admin);
+
+    // Reports cleared
+    assert_eq!(client.get_project_report_count(&project_id), 0);
+    let reports = client.get_project_reports(&project_id);
+    assert_eq!(reports.len(), 0);
+}
+
+#[test]
+fn test_clear_project_reports_allows_re_reporting() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+    let project_id = create_test_project(&client, &admin, "ProjectI");
+
+    let reporter = Address::generate(&env);
+    client.report_project(&project_id, &reporter, &valid_cid(&env));
+
+    // Cannot report twice before clearing
+    let dup = client.try_report_project(&project_id, &reporter, &valid_cid(&env));
+    assert_eq!(dup, Err(Ok(ContractError::ProjectAlreadyReported)));
+
+    // Clear reports
+    client.clear_project_reports(&project_id, &admin);
+
+    // Now the same reporter can report again
+    client.report_project(&project_id, &reporter, &valid_cid(&env));
+    assert_eq!(client.get_project_report_count(&project_id), 1);
+}
+
+#[test]
+fn test_clear_project_reports_non_admin_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+    let project_id = create_test_project(&client, &admin, "ProjectJ");
+
+    let reporter = Address::generate(&env);
+    let non_admin = Address::generate(&env);
+    client.report_project(&project_id, &reporter, &valid_cid(&env));
+
+    let result = client.try_clear_project_reports(&project_id, &non_admin);
+    assert_eq!(result, Err(Ok(ContractError::AdminOnly)));
+    // Reports still there
+    assert_eq!(client.get_project_report_count(&project_id), 1);
+}
+
+#[test]
+fn test_clear_project_reports_no_reports_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+    let project_id = create_test_project(&client, &admin, "ProjectK");
+
+    // No reports — should return the appropriate error
+    let result = client.try_clear_project_reports(&project_id, &admin);
+    assert_eq!(result, Err(Ok(ContractError::ReportsAlreadyCleared)));
+}
+
+#[test]
+fn test_clear_project_reports_missing_project_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+
+    let result = client.try_clear_project_reports(&999u64, &admin);
+    assert_eq!(result, Err(Ok(ContractError::ProjectNotFound)));
+}
+
+#[test]
+fn test_clear_project_reports_idempotent_second_clear_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+    let project_id = create_test_project(&client, &admin, "ProjectL");
+
+    let reporter = Address::generate(&env);
+    client.report_project(&project_id, &reporter, &valid_cid(&env));
+    client.clear_project_reports(&project_id, &admin);
+
+    // Second clear on now-empty project returns error
+    let result = client.try_clear_project_reports(&project_id, &admin);
+    assert_eq!(result, Err(Ok(ContractError::ReportsAlreadyCleared)));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// clear_verification_history
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Helper: get a project past the minimum age gate and request verification.
+fn request_verification_for_project(
+    env: &Env,
+    client: &crate::DongleContractClient<'_>,
+    project_id: u64,
+    owner: &Address,
+) {
+    // Push ledger past the default minimum project age (0 in tests unless set)
+    env.ledger().with_mut(|l| {
+        l.timestamp = l.timestamp.saturating_add(1);
+    });
+    client.request_verification(&project_id, owner, &valid_cid(env));
+}
+
+#[test]
+fn test_clear_verification_history_keep_zero() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+
+    // Disable minimum project age so verification can be requested immediately
+    client.set_min_project_age(&admin, &0u64);
+
+    let owner = Address::generate(&env);
+    let project_id = create_test_project(&client, &owner, "ProjectM");
+
+    // Request verification, reject, then request again — builds history
+    request_verification_for_project(&env, &client, project_id, &owner);
+    client.reject_verification(&project_id, &admin);
+    request_verification_for_project(&env, &client, project_id, &owner);
+
+    let history_before = client.get_verification_history(&project_id);
+    assert_eq!(history_before.len(), 2);
+
+    // Clear all history (keep_count = 0)
+    let removed = client.clear_verification_history(&project_id, &admin, &0u32);
+    assert_eq!(removed, 2);
+
+    let history_after = client.get_verification_history(&project_id);
+    assert_eq!(history_after.len(), 0);
+}
+
+#[test]
+fn test_clear_verification_history_keep_one() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+    client.set_min_project_age(&admin, &0u64);
+
+    let owner = Address::generate(&env);
+    let project_id = create_test_project(&client, &owner, "ProjectN");
+
+    request_verification_for_project(&env, &client, project_id, &owner);
+    client.reject_verification(&project_id, &admin);
+    request_verification_for_project(&env, &client, project_id, &owner);
+    client.reject_verification(&project_id, &admin);
+    request_verification_for_project(&env, &client, project_id, &owner);
+
+    let history_before = client.get_verification_history(&project_id);
+    assert_eq!(history_before.len(), 3);
+
+    // Keep only the most recent 1
+    let removed = client.clear_verification_history(&project_id, &admin, &1u32);
+    assert_eq!(removed, 2);
+
+    let history_after = client.get_verification_history(&project_id);
+    assert_eq!(history_after.len(), 1);
+}
+
+#[test]
+fn test_clear_verification_history_keep_count_gte_total_removes_nothing() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+    client.set_min_project_age(&admin, &0u64);
+
+    let owner = Address::generate(&env);
+    let project_id = create_test_project(&client, &owner, "ProjectO");
+
+    request_verification_for_project(&env, &client, project_id, &owner);
+
+    // keep_count=10 but only 1 record — nothing removed
+    let removed = client.clear_verification_history(&project_id, &admin, &10u32);
+    assert_eq!(removed, 0);
+
+    let history = client.get_verification_history(&project_id);
+    assert_eq!(history.len(), 1);
+}
+
+#[test]
+fn test_clear_verification_history_non_admin_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+    client.set_min_project_age(&admin, &0u64);
+
+    let owner = Address::generate(&env);
+    let project_id = create_test_project(&client, &owner, "ProjectP");
+    request_verification_for_project(&env, &client, project_id, &owner);
+
+    let non_admin = Address::generate(&env);
+    let result = client.try_clear_verification_history(&project_id, &non_admin, &0u32);
+    assert_eq!(result, Err(Ok(ContractError::AdminOnly)));
+}
+
+#[test]
+fn test_clear_verification_history_missing_project_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+
+    let result = client.try_clear_verification_history(&999u64, &admin, &0u32);
+    assert_eq!(result, Err(Ok(ContractError::ProjectNotFound)));
+}
+
+#[test]
+fn test_clear_verification_history_empty_returns_zero() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+
+    let owner = Address::generate(&env);
+    let project_id = create_test_project(&client, &owner, "ProjectQ");
+
+    // No verification requests at all
+    let removed = client.clear_verification_history(&project_id, &admin, &0u32);
+    assert_eq!(removed, 0);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// clear_renewal_history
+// ═══════════════════════════════════════════════════════════════════════════
+
+fn verify_and_approve(
+    env: &Env,
+    client: &crate::DongleContractClient<'_>,
+    project_id: u64,
+    owner: &Address,
+    admin: &Address,
+) {
+    env.ledger().with_mut(|l| {
+        l.timestamp = l.timestamp.saturating_add(1);
+    });
+    client.request_verification(&project_id, owner, &valid_cid(env));
+    client.approve_verification(&project_id, admin);
+}
+
+fn do_renewal(
+    env: &Env,
+    client: &crate::DongleContractClient<'_>,
+    project_id: u64,
+    owner: &Address,
+    admin: &Address,
+) {
+    env.ledger().with_mut(|l| {
+        l.timestamp = l.timestamp.saturating_add(1);
+    });
+    client.request_renewal(&project_id, owner, &valid_cid(env));
+    client.approve_renewal(&project_id, admin);
+}
+
+#[test]
+fn test_clear_renewal_history_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+    client.set_min_project_age(&admin, &0u64);
+
+    let owner = Address::generate(&env);
+    let project_id = create_test_project(&client, &owner, "ProjectR");
+
+    verify_and_approve(&env, &client, project_id, &owner, &admin);
+    do_renewal(&env, &client, project_id, &owner, &admin);
+    do_renewal(&env, &client, project_id, &owner, &admin);
+
+    let history_before = client.get_renewal_history(&project_id, &0u32, &100u32);
+    assert_eq!(history_before.len(), 2);
+
+    let removed = client.clear_renewal_history(&project_id, &admin);
+    assert_eq!(removed, 2);
+
+    let history_after = client.get_renewal_history(&project_id, &0u32, &100u32);
+    assert_eq!(history_after.len(), 0);
+}
+
+#[test]
+fn test_clear_renewal_history_empty_returns_zero() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+    client.set_min_project_age(&admin, &0u64);
+
+    let owner = Address::generate(&env);
+    let project_id = create_test_project(&client, &owner, "ProjectS");
+
+    verify_and_approve(&env, &client, project_id, &owner, &admin);
+    // No renewals submitted — clear should return 0
+    let removed = client.clear_renewal_history(&project_id, &admin);
+    assert_eq!(removed, 0);
+}
+
+#[test]
+fn test_clear_renewal_history_non_admin_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+    client.set_min_project_age(&admin, &0u64);
+
+    let owner = Address::generate(&env);
+    let project_id = create_test_project(&client, &owner, "ProjectT");
+    verify_and_approve(&env, &client, project_id, &owner, &admin);
+    do_renewal(&env, &client, project_id, &owner, &admin);
+
+    let non_admin = Address::generate(&env);
+    let result = client.try_clear_renewal_history(&project_id, &non_admin);
+    assert_eq!(result, Err(Ok(ContractError::AdminOnly)));
+
+    // History untouched
+    let history = client.get_renewal_history(&project_id, &0u32, &100u32);
+    assert_eq!(history.len(), 1);
+}
+
+#[test]
+fn test_clear_renewal_history_missing_project_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+
+    let result = client.try_clear_renewal_history(&999u64, &admin);
+    assert_eq!(result, Err(Ok(ContractError::ProjectNotFound)));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// admin reactivate_project
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_admin_can_reactivate_archived_project() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+
+    let owner = Address::generate(&env);
+    let project_id = create_test_project(&client, &owner, "ProjectU");
+
+    client.archive_project(&project_id, &owner);
+    assert!(client.get_project(&project_id).unwrap().archived);
+
+    // Admin reactivates (not the owner)
+    client.reactivate_project(&project_id, &admin);
+    assert!(!client.get_project(&project_id).unwrap().archived);
+}
+
+#[test]
+fn test_archive_already_archived_returns_error() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+
+    let owner = Address::generate(&env);
+    let project_id = create_test_project(&client, &owner, "ProjectV");
+    client.archive_project(&project_id, &owner);
+
+    let result = client.try_archive_project(&project_id, &owner);
+    assert_eq!(result, Err(Ok(ContractError::ProjectAlreadyArchived)));
+}
+
+#[test]
+fn test_reactivate_not_archived_returns_error() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+
+    let owner = Address::generate(&env);
+    let project_id = create_test_project(&client, &owner, "ProjectW");
+
+    let result = client.try_reactivate_project(&project_id, &owner);
+    assert_eq!(result, Err(Ok(ContractError::ProjectNotArchived)));
+}
+
+#[test]
+fn test_stranger_cannot_archive_project() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+
+    let owner = Address::generate(&env);
+    let stranger = Address::generate(&env);
+    let project_id = create_test_project(&client, &owner, "ProjectX");
+
+    let result = client.try_archive_project(&project_id, &stranger);
+    assert_eq!(result, Err(Ok(ContractError::Unauthorized)));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// index consistency after cleanup
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_admin_delete_review_stats_multiple_reviews() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+    let project_id = create_test_project(&client, &admin, "ProjectY");
+
+    let r1 = Address::generate(&env);
+    let r2 = Address::generate(&env);
+    let r3 = Address::generate(&env);
+    client.add_review(&project_id, &r1, &4, &None);
+    client.add_review(&project_id, &r2, &2, &None);
+    client.add_review(&project_id, &r3, &5, &None);
+
+    let stats = client.get_project_stats(&project_id);
+    assert_eq!(stats.review_count, 3);
+    // ratings stored as x*100: (400+200+500) = 1100
+    assert_eq!(stats.rating_sum, 1100);
+
+    // Admin removes the rating-2 review
+    client.admin_delete_review(&project_id, &r2, &admin);
+    let stats2 = client.get_project_stats(&project_id);
+    assert_eq!(stats2.review_count, 2);
+    assert_eq!(stats2.rating_sum, 900); // 400+500
+
+    // Remaining reviews still accessible
+    assert!(client.get_review(&project_id, &r1).is_some());
+    assert!(client.get_review(&project_id, &r2).is_none());
+    assert!(client.get_review(&project_id, &r3).is_some());
+}
+
+#[test]
+fn test_clear_reports_then_report_updates_count_correctly() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+    let project_id = create_test_project(&client, &admin, "ProjectZ");
+
+    let r1 = Address::generate(&env);
+    let r2 = Address::generate(&env);
+    client.report_project(&project_id, &r1, &valid_cid(&env));
+    client.report_project(&project_id, &r2, &valid_cid(&env));
+    assert_eq!(client.get_project_report_count(&project_id), 2);
+
+    client.clear_project_reports(&project_id, &admin);
+    assert_eq!(client.get_project_report_count(&project_id), 0);
+
+    // Fresh reports after clearing
+    let r3 = Address::generate(&env);
+    client.report_project(&project_id, &r3, &valid_cid(&env));
+    assert_eq!(client.get_project_report_count(&project_id), 1);
+}
+
+#[test]
+fn test_archived_project_still_accessible_via_get_project() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+
+    let owner = Address::generate(&env);
+    let project_id = create_test_project(&client, &owner, "ProjectAA");
+    client.archive_project(&project_id, &owner);
+
+    let project = client.get_project(&project_id);
+    assert!(project.is_some());
+    assert!(project.unwrap().archived);
+}
+
+#[test]
+fn test_archived_project_excluded_from_list_projects() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = setup(&env);
+
+    let owner = Address::generate(&env);
+    let id1 = create_test_project(&client, &owner, "ProjectBB");
+    let id2 = create_test_project(&client, &owner, "ProjectCC");
+
+    client.archive_project(&id1, &owner);
+
+    let projects = client.list_projects(&1u64, &100u32);
+    assert_eq!(projects.len(), 1);
+    assert_eq!(projects.get(0).unwrap().id, id2);
+}

--- a/dongle-smartcontract/src/tests/mod.rs
+++ b/dongle-smartcontract/src/tests/mod.rs
@@ -12,6 +12,7 @@ mod review;
 // New test modules
 mod authorization;
 mod basic_new_features;
+mod cleanup;
 mod events;
 mod moderation;
 mod pagination;

--- a/dongle-smartcontract/src/types.rs
+++ b/dongle-smartcontract/src/types.rs
@@ -97,10 +97,9 @@ pub struct Project {
     pub logo_cid: Option<String>,
     pub metadata_cid: Option<String>,
     pub verification_status: VerificationStatus,
-    pub is_archived: bool,
+    pub archived: bool,
     pub created_at: u64,
     pub updated_at: u64,
-    pub archived: bool,
     pub tags: Option<Vec<String>>,
     pub social_links: Option<Map<String, String>>,
 }

--- a/dongle-smartcontract/src/verification_registry.rs
+++ b/dongle-smartcontract/src/verification_registry.rs
@@ -650,6 +650,131 @@ impl VerificationRegistry {
         let verification = Self::get_verification(env, project_id)?;
         Ok(verification.expires_at != 0 && env.ledger().timestamp() > verification.expires_at)
     }
+
+    /// Admin-only: prune verification history for a project, retaining only the
+    /// most recent `keep_count` records. Pass `keep_count = 0` to remove all
+    /// historical records (the live `Verification(project_id)` record is never removed).
+    ///
+    /// This frees storage for projects that have accumulated many verification
+    /// requests (e.g. repeated rejection/re-submission cycles).
+    pub fn clear_verification_history(
+        env: &Env,
+        project_id: u64,
+        admin: &Address,
+        keep_count: u32,
+    ) -> Result<u32, ContractError> {
+        // Auth: admin only
+        if !crate::admin_manager::AdminManager::is_admin(env, admin) {
+            return Err(ContractError::AdminOnly);
+        }
+
+        // Project must exist
+        crate::project_registry::ProjectRegistry::get_project(env, project_id)
+            .ok_or(ContractError::ProjectNotFound)?;
+
+        let history_key = StorageKey::ProjectVerificationHistory(project_id);
+        let history: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&history_key)
+            .unwrap_or_else(|| Vec::new(env));
+
+        let total = history.len();
+        if total == 0 {
+            // Nothing to prune
+            return Ok(0);
+        }
+
+        // Determine how many to remove from the front (oldest entries)
+        let keep = core::cmp::min(keep_count, total);
+        let remove_count = total - keep;
+
+        if remove_count == 0 {
+            return Ok(0);
+        }
+
+        // Remove individual VerificationRecord entries for pruned request IDs
+        for i in 0..remove_count {
+            if let Some(req_id) = history.get(i) {
+                env.storage()
+                    .persistent()
+                    .remove(&StorageKey::VerificationRecord(req_id));
+            }
+        }
+
+        // Build the retained history (most recent `keep` entries)
+        let mut retained = Vec::new(env);
+        for i in remove_count..total {
+            if let Some(req_id) = history.get(i) {
+                retained.push_back(req_id);
+            }
+        }
+
+        if retained.is_empty() {
+            env.storage().persistent().remove(&history_key);
+        } else {
+            env.storage().persistent().set(&history_key, &retained);
+        }
+
+        crate::events::publish_verification_history_cleared_event(
+            env,
+            project_id,
+            admin.clone(),
+            remove_count,
+            keep,
+        );
+
+        Ok(remove_count)
+    }
+
+    /// Admin-only: clear the renewal history for a project, freeing storage
+    /// accumulated from repeated renewal cycles.
+    /// Returns the number of renewal records removed.
+    pub fn clear_renewal_history(
+        env: &Env,
+        project_id: u64,
+        admin: &Address,
+    ) -> Result<u32, ContractError> {
+        // Auth: admin only
+        if !crate::admin_manager::AdminManager::is_admin(env, admin) {
+            return Err(ContractError::AdminOnly);
+        }
+
+        // Project must exist
+        crate::project_registry::ProjectRegistry::get_project(env, project_id)
+            .ok_or(ContractError::ProjectNotFound)?;
+
+        let count: u32 = env
+            .storage()
+            .persistent()
+            .get(&StorageKey::VerificationRenewalCount(project_id))
+            .unwrap_or(0);
+
+        if count == 0 {
+            return Ok(0);
+        }
+
+        // Remove every individual renewal record
+        for index in 0..count {
+            env.storage()
+                .persistent()
+                .remove(&StorageKey::VerificationRenewalHistory(project_id, index));
+        }
+
+        // Reset the counter
+        env.storage()
+            .persistent()
+            .remove(&StorageKey::VerificationRenewalCount(project_id));
+
+        crate::events::publish_renewal_history_cleared_event(
+            env,
+            project_id,
+            admin.clone(),
+            count,
+        );
+
+        Ok(count)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
- Remove unused VerificationStatus import from events module

- Add comprehensive project lifecycle events: ProjectArchivedEvent, ProjectReactivatedEvent, ProjectOwnershipTransferredEvent

- Add project reporting and management events: ProjectReportedEvent, ProjectReportsClearedEvent

- Add project metadata update events: ProjectTagsUpdatedEvent, ProjectSocialLinksUpdatedEvent

- Add admin management events: AdminAddedEvent, AdminRemovedEvent

- Add review action events: ReviewReportedEvent, ReviewHiddenEvent, ReviewRestoredEvent, ReviewDeletedByAdminEvent

- Add verification history management events: VerificationHistoryClearedEvent, RenewalHistoryClearedEvent

- Restructure event definitions with organizational section header

- Add three new error types: ProjectAlreadyArchived, ProjectNotArchived, ReportsAlreadyCleared

- Add comprehensive test cleanup utility module

- Update all registries to emit new events for state changes

- Update type definitions and error handling across project, report, review, and verification 


Closes: #162