### PR TITLE
feat: implement structured deployment manifest tracking with automated CI validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,14 @@ env:
   RUSTFLAGS: "-D warnings"
 
 jobs:
+  validate-manifest:
+    name: Validate Deployment Manifest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run validation script
+        run: python3 scripts/validate_deployments.py
+
   fmt:
     name: Formatting
     runs-on: ubuntu-latest

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,76 @@
+# Dongle Smart Contract Deployment Documentation
+
+This repository uses a structured deployment manifest, [`deployments.json`](file:///home/chidubem/ProjectFolder/DripProjects/Dongle-Smartcontract/deployments.json), to track and record smart contract deployments to Stellar networks (such as Testnet and Mainnet).
+
+---
+
+## Manifest Location & Schema
+
+- **Manifest File:** [`deployments.json`](file:///home/chidubem/ProjectFolder/DripProjects/Dongle-Smartcontract/deployments.json)
+- **JSON Schema:** [`deployments.schema.json`](file:///home/chidubem/ProjectFolder/DripProjects/Dongle-Smartcontract/deployments.schema.json)
+
+The manifest is organized by network environment:
+- `testnet`: Array of deployments on Stellar Testnet.
+- `mainnet`: Array of deployments on Stellar Mainnet.
+
+### Fields per Deployment Entry
+
+Every entry in the deployment lists must contain:
+
+| Field Name | Type | Description | Format / Pattern |
+|---|---|---|---|
+| `contract_id` | String | The deployed contract address on Stellar | 56 alphanumeric characters starting with `C` |
+| `wasm_hash` | String | Hexadecimal hash of the built contract WASM file | 64 hexadecimal characters |
+| `deployer` | String | The public key / contract address that performed the deploy | 56 alphanumeric characters starting with `G` or `C` |
+| `timestamp` | String | The date and time the deployment was executed | ISO 8601 / RFC 3339 format (e.g., `YYYY-MM-DDTHH:MM:SSZ`) |
+
+---
+
+## How to Update the Manifest After Deploys
+
+Whenever you deploy a new version of the contract or initialize a new instance, update `deployments.json` by adding a new record to the corresponding network array.
+
+### Step-by-Step Guide
+
+#### 1. Retrieve Deployment Information
+
+After executing the deployment command, gather the necessary info:
+
+- **Contract ID:** Printed by the Soroban CLI output when running `soroban contract deploy`.
+- **WASM Hash:** Can be retrieved using the Soroban CLI by printing or checking the hash of the built `.wasm` file:
+  ```bash
+  soroban contract install --wasm target/wasm32-unknown-unknown/release/dongle_contract.wasm --network <network> --source <identity>
+  ```
+  *(Note: This returns the WASM hash which is required prior to deployment. You can also get it from build output / target hash.)*
+- **Deployer Account:** The Stellar public key corresponding to the source identity used for deployment (e.g., Alice's key: `GDAMR...`).
+- **Timestamp:** The UTC timestamp of the deployment.
+
+#### 2. Edit `deployments.json`
+
+Append the entry to the end of the list for the appropriate network in `deployments.json`.
+
+**Example:**
+```json
+{
+  "contract_id": "CCWUXOTO2RJK5QRPNDP2K2OTW247V7OVDJ3Z4R3V47N4TZOQCXJ42N73",
+  "wasm_hash": "a4b5c6d7e8f901a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f901a2b3c4d5e6f7",
+  "deployer": "GDAMR3SOTO2RJK5QRPNDP2K2OTW247V7OVDJ3Z4R3V47N4TZOQCXJ42N",
+  "timestamp": "2026-06-24T12:00:00Z"
+}
+```
+
+#### 3. Validate the Changes Locally
+
+Always run the validation script locally to ensure there are no syntax errors or invalid formats:
+
+```bash
+python3 scripts/validate_deployments.py
+```
+
+Ensure it exits with `✓ Deployment manifest validation passed successfully!`.
+
+---
+
+## CI/CD Validation
+
+To prevent invalid, broken, or undocumented deployments from entering the `main` branch, the CI/CD pipeline runs `scripts/validate_deployments.py` on every push and pull request. If the script fails, the CI check will fail, blocking merges.

--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ Dongle Smart Contract (Soroban)
 
 This is an **actively evolving open-source project**.
 
+## Deployments
+
+Contract deployments on Stellar networks are tracked in [deployments.json](file:///home/chidubem/ProjectFolder/DripProjects/Dongle-Smartcontract/deployments.json). For details on the manifest format, how to update it, and how validation works, see the [Deployment Documentation](file:///home/chidubem/ProjectFolder/DripProjects/Dongle-Smartcontract/DEPLOYMENT.md).
+
 ## Open Source & Contributions
 
 Dongle is open-source and welcomes contributions.

--- a/deployments.json
+++ b/deployments.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "./deployments.schema.json",
+  "testnet": [
+    {
+      "contract_id": "CCWUXOTO2RJK5QRPNDP2K2OTW247V7OVDJ3Z4R3V47N4TZOQCXJ42N73",
+      "wasm_hash": "a4b5c6d7e8f901a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f901a2b3c4d5e6f7",
+      "deployer": "GDAMR3SOTO2RJK5QRPNDP2K2OTW247V7OVDJ3Z4R3V47N4TZOQCXJ42N",
+      "timestamp": "2026-06-24T12:00:00Z"
+    }
+  ],
+  "mainnet": []
+}

--- a/deployments.schema.json
+++ b/deployments.schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Dongle Smart Contract Deployment Manifest",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "testnet": {
+      "type": "array",
+      "description": "List of deployments on Stellar Testnet",
+      "items": {
+        "$ref": "#/definitions/deploymentEntry"
+      }
+    },
+    "mainnet": {
+      "type": "array",
+      "description": "List of deployments on Stellar Mainnet",
+      "items": {
+        "$ref": "#/definitions/deploymentEntry"
+      }
+    }
+  },
+  "required": ["testnet", "mainnet"],
+  "additionalProperties": false,
+  "definitions": {
+    "deploymentEntry": {
+      "type": "object",
+      "properties": {
+        "contract_id": {
+          "type": "string",
+          "description": "Stellar Contract ID (starts with 'C', 56 characters)",
+          "pattern": "^C[A-Z2-7]{55}$"
+        },
+        "wasm_hash": {
+          "type": "string",
+          "description": "Hexadecimal hash of the built contract WASM (64 characters)",
+          "pattern": "^[a-fA-F0-9]{64}$"
+        },
+        "deployer": {
+          "type": "string",
+          "description": "Stellar account public key or contract address that executed the deployment (starts with 'G' or 'C', 56 characters)",
+          "pattern": "^[GC][A-Z2-7]{55}$"
+        },
+        "timestamp": {
+          "type": "string",
+          "description": "Deployment ISO 8601 / RFC 3339 timestamp",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?(?:Z|[+-]\\d{2}:?\\d{2})$"
+        }
+      },
+      "required": ["contract_id", "wasm_hash", "deployer", "timestamp"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/dongle-smartcontract/README.md
+++ b/dongle-smartcontract/README.md
@@ -72,6 +72,9 @@ soroban keys fund alice --network testnet
 make deploy-testnet
 ```
 
+> [!IMPORTANT]
+> After deploying, you must document the deployment in the project-wide deployment manifest. Please refer to the root [Deployment Documentation](../DEPLOYMENT.md) for details on how to update [`deployments.json`](../deployments.json).
+
 ---
 
 ## Usage Examples

--- a/scripts/validate_deployments.py
+++ b/scripts/validate_deployments.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+import json
+import os
+import re
+import sys
+
+def main():
+    # Find the repository root
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    root_dir = os.path.dirname(script_dir)
+    manifest_path = os.path.join(root_dir, "deployments.json")
+
+    print(f"Validating deployment manifest: {manifest_path}")
+
+    if not os.path.exists(manifest_path):
+        print(f"Error: Manifest file '{manifest_path}' does not exist.")
+        sys.exit(1)
+
+    try:
+        with open(manifest_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except json.JSONDecodeError as e:
+        print(f"Error: Manifest file is not valid JSON. {e}")
+        sys.exit(1)
+
+    # Validate structure
+    if not isinstance(data, dict):
+        print("Error: Root of manifest must be a JSON object.")
+        sys.exit(1)
+
+    # Check top-level keys
+    allowed_keys = {"$schema", "testnet", "mainnet"}
+    required_keys = {"testnet", "mainnet"}
+    
+    actual_keys = set(data.keys())
+    
+    missing_keys = required_keys - actual_keys
+    if missing_keys:
+        print(f"Error: Missing required top-level keys: {missing_keys}")
+        sys.exit(1)
+
+    extra_keys = actual_keys - allowed_keys
+    if extra_keys:
+        print(f"Error: Unexpected top-level keys: {extra_keys}")
+        sys.exit(1)
+
+    # Regex definitions matching the JSON schema
+    contract_id_pattern = re.compile(r"^C[A-Z2-7]{55}$")
+    wasm_hash_pattern = re.compile(r"^[a-fA-F0-9]{64}$")
+    deployer_pattern = re.compile(r"^[GC][A-Z2-7]{55}$")
+    # ISO 8601 format regex
+    timestamp_pattern = re.compile(
+        r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})$"
+    )
+
+    errors = []
+
+    for network in ["testnet", "mainnet"]:
+        entries = data[network]
+        if not isinstance(entries, list):
+            errors.append(f"Network '{network}' must be an array of deployment entries.")
+            continue
+
+        for idx, entry in enumerate(entries):
+            loc = f"{network}[{idx}]"
+            if not isinstance(entry, dict):
+                errors.append(f"Entry {loc} must be a JSON object.")
+                continue
+
+            # Check for required properties
+            entry_keys = set(entry.keys())
+            req_fields = {"contract_id", "wasm_hash", "deployer", "timestamp"}
+            
+            missing_fields = req_fields - entry_keys
+            if missing_fields:
+                errors.append(f"Entry {loc} is missing required fields: {missing_fields}")
+                
+            extra_fields = entry_keys - req_fields
+            if extra_fields:
+                errors.append(f"Entry {loc} has unexpected fields: {extra_fields}")
+
+            # If there are missing fields, skip format validation for those fields
+            if "contract_id" in entry:
+                cid = entry["contract_id"]
+                if not isinstance(cid, str) or not contract_id_pattern.match(cid):
+                    errors.append(
+                        f"Entry {loc}.contract_id ('{cid}') is invalid. "
+                        f"Must be a 56-character Stellar Contract ID starting with 'C'."
+                    )
+
+            if "wasm_hash" in entry:
+                whash = entry["wasm_hash"]
+                if not isinstance(whash, str) or not wasm_hash_pattern.match(whash):
+                    errors.append(
+                        f"Entry {loc}.wasm_hash ('{whash}') is invalid. "
+                        f"Must be a 64-character hex string."
+                    )
+
+            if "deployer" in entry:
+                deployer = entry["deployer"]
+                if not isinstance(deployer, str) or not deployer_pattern.match(deployer):
+                    errors.append(
+                        f"Entry {loc}.deployer ('{deployer}') is invalid. "
+                        f"Must be a 56-character Stellar account or contract ID starting with 'G' or 'C'."
+                    )
+
+            if "timestamp" in entry:
+                ts = entry["timestamp"]
+                if not isinstance(ts, str) or not timestamp_pattern.match(ts):
+                    errors.append(
+                        f"Entry {loc}.timestamp ('{ts}') is invalid. "
+                        f"Must be a valid ISO 8601 / RFC 3339 datetime string (e.g. '2026-06-24T12:00:00Z')."
+                    )
+
+    if errors:
+        print("\nValidation failed with the following errors:")
+        for err in errors:
+            print(f"  - {err}")
+        sys.exit(1)
+
+    print("\n✓ Deployment manifest validation passed successfully!")
+    sys.exit(0)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION

# PR Description: Add Contract Deployment Manifest (#203)

Closes #203 

## Goal
Resolve issue #203 by introducing a structured deployment manifest for the Dongle Smart Contract on Stellar networks. This tracks contract IDs, WASM hashes, deployers, and timestamps for deployments on both Testnet and Mainnet, with automated validation run in CI.

## Proposed Changes

### 1. Configuration & Manifest Format
- **`deployments.json`**: Created the main deployment manifest file at the repository root, populated with a valid example Testnet deployment.
- **`deployments.schema.json`**: Created a formal JSON Schema to enforce type constraints, formats, and required fields (`contract_id`, `wasm_hash`, `deployer`, `timestamp`) for IDE autocomplete and schema validation.

### 2. CI/CD Validation
- **`scripts/validate_deployments.py`**: Added a zero-dependency Python script that validates `deployments.json` against the layout and format requirements (e.g. matching Stellar address starts and lengths).
- **`.github/workflows/ci.yml`**: Added a new `validate-manifest` job that executes the validation script on every push and pull request to prevent incorrect manifest updates.

### 3. Documentation
- **`DEPLOYMENT.md`**: Created a guide explaining the schema, required fields, and step-by-step instructions for developers to update the manifest after deploying.
- **`README.md` & `dongle-smartcontract/README.md`**: Linked the new deployment documentation and added callouts to prompt developers to document deployments after running `make deploy-testnet`.

---

## Verification Results
- **Validation Execution**: Confirmed that `python3 scripts/validate_deployments.py` successfully validates the example manifest.
- **Unit Testing**: Verified the validation script logic against 6 unit test scenarios (valid manifest, missing top-level keys, invalid contract ID formats, invalid WASM hashes, invalid deployer formats, and malformed timestamps). All test cases pass.
