### PR TITLE
feat: fee boundary validation, review tombstones, sorting, and update cooldown

### DIFF
--- a/dongle-smartcontract/src/constants.rs
+++ b/dongle-smartcontract/src/constants.rs
@@ -145,3 +145,7 @@ pub const TIMELOCK_MIN_DELAY: u64 = 86400;
 /// After this window, the payment record is considered expired and the
 /// verification request is rejected until the owner re-pays.
 pub const FEE_PAYMENT_EXPIRY_SECONDS: u64 = 7 * 24 * 60 * 60;
+
+/// Minimum seconds a reviewer must wait before updating their review again (default: 1 hour).
+/// Configurable by changing this constant.
+pub const REVIEW_UPDATE_COOLDOWN_SECONDS: u64 = 3600;

--- a/dongle-smartcontract/src/fee_manager.rs
+++ b/dongle-smartcontract/src/fee_manager.rs
@@ -90,6 +90,11 @@ impl FeeManager {
 
         let amount = config.verification_fee;
         if amount > 0 {
+            // Safety: fee amounts are stored as u128 but the token interface requires i128.
+            // Reject any value that exceeds i128::MAX to prevent a silent truncating cast.
+            if amount > i128::MAX as u128 {
+                return Err(ContractError::InvalidProjectData);
+            }
             // set_fee enforces that token is Some when fees are non-zero, so this
             // ok_or branch is a defensive guard against corrupted storage state.
             let token_address = config.token.ok_or(ContractError::NativeFeeNotSupported)?;
@@ -219,6 +224,11 @@ impl FeeManager {
 
         let amount = config.registration_fee;
         if amount > 0 {
+            // Safety: fee amounts are stored as u128 but the token interface requires i128.
+            // Reject any value that exceeds i128::MAX to prevent a silent truncating cast.
+            if amount > i128::MAX as u128 {
+                return Err(ContractError::InvalidProjectData);
+            }
             // Defensive guard — set_fee already rejects None token with non-zero fees.
             let token_address = config.token.ok_or(ContractError::NativeFeeNotSupported)?;
             let client = soroban_sdk::token::Client::new(env, &token_address);

--- a/dongle-smartcontract/src/lib.rs
+++ b/dongle-smartcontract/src/lib.rs
@@ -44,7 +44,8 @@ use crate::types::{
     AdminActionEntry, AdminProposal, ClaimRequest, ClaimStatus, Collection, DependencyRef,
     DisputeResolutionAction, DisputeStatus, DuplicateDispute, FeeConfig, FeePaymentRecord, Project,
     ProjectDependency, ProjectRegistrationParams, ProjectReport, ProjectStats, ProjectUpdateParams,
-    ProposalPayload, Review, SecurityContactStatus, TimelockAction, VerificationRecord,
+    ProposalPayload, Review, ReviewSortMode, ReviewTombstone, SecurityContactStatus,
+    TimelockAction, VerificationRecord,
     VerificationStatus,
 };
 use crate::verification_registry::VerificationRegistry;
@@ -439,6 +440,27 @@ impl DongleContract {
         admin: Address,
     ) -> Result<(), ContractError> {
         ReviewRegistry::admin_delete_review(&env, project_id, reviewer, admin)
+    }
+
+    /// Get the deletion tombstone for a review, distinguishing deleted vs never-existed.
+    pub fn get_review_tombstone(
+        env: Env,
+        project_id: u64,
+        reviewer: Address,
+    ) -> Option<ReviewTombstone> {
+        ReviewRegistry::get_review_tombstone(&env, project_id, reviewer)
+    }
+
+    /// List reviews sorted by the given sort mode with pagination.
+    /// Sorting is performed on-chain in-memory; compute cost scales with review count.
+    pub fn list_reviews_sorted(
+        env: Env,
+        project_id: u64,
+        start_id: u32,
+        limit: u32,
+        sort_mode: ReviewSortMode,
+    ) -> Vec<Review> {
+        ReviewRegistry::list_reviews_sorted(&env, project_id, start_id, limit, sort_mode)
     }
 
     // --- Verification Registry ---

--- a/dongle-smartcontract/src/review_registry.rs
+++ b/dongle-smartcontract/src/review_registry.rs
@@ -3,15 +3,15 @@
 use crate::admin_action_log::AdminActionLog;
 use crate::constants::{
     MAX_CID_LEN, MAX_PAGE_LIMIT, MAX_REVIEWS_PER_PROJECT, MAX_REVIEWS_PER_USER, RATING_MAX,
-    RATING_MIN,
+    RATING_MIN, REVIEW_UPDATE_COOLDOWN_SECONDS,
 };
 use crate::errors::ContractError;
 use crate::events::publish_review_event;
 use crate::project_registry::ProjectRegistry;
 use crate::rating_calculator::RatingCalculator;
-use crate::storage_keys::StorageKey;
+use crate::storage_keys::{ExtensionKey, StorageKey};
 use crate::storage_manager::StorageManager;
-use crate::types::{AdminActionType, Project, ProjectStats, Review, ReviewAction};
+use crate::types::{AdminActionType, Project, ProjectStats, Review, ReviewAction, ReviewSortMode, ReviewTombstone};
 use crate::utils::Utils;
 use soroban_sdk::{Address, Env, String, Vec};
 
@@ -193,6 +193,19 @@ impl ReviewRegistry {
             return Err(ContractError::NotReviewOwner);
         }
 
+        // Cooldown: reject update if within REVIEW_UPDATE_COOLDOWN_SECONDS of the last update.
+        // Note: ContractError::InvalidStatus (9) is reused as the cooldown error because
+        // Soroban SDK 22 #[contracterror] is limited to 50 variants and this enum is full.
+        // A dedicated ReviewCooldownActive variant should be introduced when a variant slot
+        // is freed in a future refactor.
+        let cooldown_key = ExtensionKey::ReviewLastUpdated(project_id, reviewer.clone());
+        if let Some(last_updated_at) = env.storage().persistent().get::<_, u64>(&cooldown_key) {
+            let now_ts = env.ledger().timestamp();
+            if now_ts.saturating_sub(last_updated_at) < REVIEW_UPDATE_COOLDOWN_SECONDS {
+                return Err(ContractError::InvalidStatus);
+            }
+        }
+
         // Mutation phase
         let old_rating = review.rating;
         let now = env.ledger().timestamp();
@@ -229,6 +242,11 @@ impl ReviewRegistry {
                 average_rating: new_avg,
             },
         );
+
+        // Record the update timestamp for cooldown enforcement on subsequent updates.
+        env.storage()
+            .persistent()
+            .set(&ExtensionKey::ReviewLastUpdated(project_id, reviewer.clone()), &now);
 
         publish_review_event(
             env,
@@ -318,6 +336,12 @@ impl ReviewRegistry {
 
         // Perform all mutations
         env.storage().persistent().remove(&review_key);
+        // Store a tombstone so indexers can distinguish deleted vs never-existed.
+        let now = env.ledger().timestamp();
+        env.storage().persistent().set(
+            &ExtensionKey::ReviewTombstone(project_id, reviewer.clone()),
+            &ReviewTombstone { project_id, reviewer: reviewer.clone(), deleted_at: now },
+        );
         env.storage().persistent().set(
             &StorageKey::ProjectStats(project_id),
             &ProjectStats {
@@ -347,7 +371,6 @@ impl ReviewRegistry {
         // as ReviewReport keys are dedup guards keyed by (project_id, reviewer, reporter)
         // and those will become orphaned but harmless once the review is gone.
 
-        let now = env.ledger().timestamp();
         publish_review_event(
             env,
             project_id,
@@ -439,6 +462,12 @@ impl ReviewRegistry {
 
         // Apply all mutations
         env.storage().persistent().remove(&review_key);
+        // Store a tombstone so indexers can distinguish deleted vs never-existed.
+        let now = env.ledger().timestamp();
+        env.storage().persistent().set(
+            &ExtensionKey::ReviewTombstone(project_id, reviewer.clone()),
+            &ReviewTombstone { project_id, reviewer: reviewer.clone(), deleted_at: now },
+        );
         env.storage().persistent().set(
             &StorageKey::ProjectStats(project_id),
             &ProjectStats {
@@ -456,7 +485,6 @@ impl ReviewRegistry {
             &new_project_reviews,
         );
 
-        let now = env.ledger().timestamp();
         crate::events::publish_review_deleted_by_admin_event(
             env,
             project_id,
@@ -473,7 +501,6 @@ impl ReviewRegistry {
             None,
         );
 
-        let _ = now;
         Ok(())
     }
 
@@ -869,5 +896,81 @@ impl ReviewRegistry {
         );
 
         Ok(())
+    }
+
+    /// Retrieve the deletion tombstone for a review, if one exists.
+    /// Returns `Some` when the review was deleted; `None` when it never existed.
+    pub fn get_review_tombstone(env: &Env, project_id: u64, reviewer: Address) -> Option<ReviewTombstone> {
+        env.storage()
+            .persistent()
+            .get(&ExtensionKey::ReviewTombstone(project_id, reviewer))
+    }
+
+    /// List reviews sorted by the requested `sort_mode` with pagination.
+    ///
+    /// # On-chain in-memory sort
+    /// This fetches all non-hidden reviews for the project, sorts them entirely
+    /// in the contract's working memory, then applies pagination. For projects
+    /// with many reviews this increases compute budget usage linearly with the
+    /// total review count. Use `list_reviews` (insertion-order) when sorting is
+    /// not required.
+    pub fn list_reviews_sorted(
+        env: &Env,
+        project_id: u64,
+        start_id: u32,
+        limit: u32,
+        sort_mode: ReviewSortMode,
+    ) -> Vec<Review> {
+        let effective_limit = if limit == 0 || limit > MAX_PAGE_LIMIT { MAX_PAGE_LIMIT } else { limit };
+
+        let reviewers: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&StorageKey::ProjectReviews(project_id))
+            .unwrap_or_else(|| Vec::new(env));
+
+        // Collect all non-hidden reviews.
+        let mut all: Vec<Review> = Vec::new(env);
+        for i in 0..reviewers.len() {
+            if let Some(reviewer) = reviewers.get(i) {
+                if let Some(review) = Self::get_review(env, project_id, reviewer) {
+                    if !review.hidden {
+                        all.push_back(review);
+                    }
+                }
+            }
+        }
+
+        // Bubble-sort in-memory by the requested mode.
+        let n = all.len();
+        for i in 0..n {
+            for j in 0..n.saturating_sub(i + 1) {
+                let a = all.get(j).unwrap();
+                let b = all.get(j + 1).unwrap();
+                let swap = match sort_mode {
+                    ReviewSortMode::Newest => a.created_at < b.created_at,
+                    ReviewSortMode::Oldest => a.created_at > b.created_at,
+                    ReviewSortMode::RatingHigh => a.rating < b.rating,
+                    ReviewSortMode::RatingLow => a.rating > b.rating,
+                };
+                if swap {
+                    all.set(j, b);
+                    all.set(j + 1, a);
+                }
+            }
+        }
+
+        // Apply pagination.
+        let mut out = Vec::new(env);
+        if start_id >= n {
+            return out;
+        }
+        let end = core::cmp::min(start_id.saturating_add(effective_limit), n);
+        for i in start_id..end {
+            if let Some(review) = all.get(i) {
+                out.push_back(review);
+            }
+        }
+        out
     }
 }

--- a/dongle-smartcontract/src/storage_keys.rs
+++ b/dongle-smartcontract/src/storage_keys.rs
@@ -148,6 +148,10 @@ pub enum ExtensionKey {
     FeeConfigHistoryCount,
     /// Fee config history entry by index (oldest = 0).
     FeeConfigHistoryEntry(u32),
+    /// Tombstone for a deleted review (project_id, reviewer). Allows indexers to distinguish deleted vs never-existed.
+    ReviewTombstone(u64, Address),
+    /// Timestamp of the last successful update for a review (project_id, reviewer). Used for cooldown enforcement.
+    ReviewLastUpdated(u64, Address),
     /// Fee payment details for a project (payer, amount, token, timestamp).
     FeePaymentDetails(u64),
     /// Fee payment details for a registration (payer, amount, token, timestamp).

--- a/dongle-smartcontract/src/tests/fee_boundary.rs
+++ b/dongle-smartcontract/src/tests/fee_boundary.rs
@@ -1,0 +1,98 @@
+//! Boundary tests for fee amounts: u128 storage / i128 transfer safety (#221).
+
+use crate::errors::ContractError;
+use crate::tests::fixtures::{create_test_project, setup_contract};
+use crate::DongleContractClient;
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+fn setup_with_token(env: &Env) -> (DongleContractClient<'_>, Address, Address) {
+    let (client, admin) = setup_contract(env);
+    let token_admin = Address::generate(env);
+    let token = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+    (client, admin, token)
+}
+
+fn mint_token(env: &Env, token: &Address, to: &Address, amount: i128) {
+    soroban_sdk::token::StellarAssetClient::new(env, token).mint(to, &amount);
+}
+
+// ─── Zero fee ────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_zero_fee_succeeds_without_transfer() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup_contract(&env);
+    let owner = Address::generate(&env);
+    // fee = 0, no token required
+    client.set_fee(&admin, &None, &0u128, &0u128, &admin);
+    let project_id = create_test_project(&client, &owner, "ZeroFeeProject");
+    // pay_fee with zero fee should succeed without any token transfer
+    client.pay_fee(&owner, &project_id, &None);
+    assert!(client.is_fee_paid(&project_id));
+}
+
+// ─── Small valid fee ─────────────────────────────────────────────────────────
+
+#[test]
+fn test_small_fee_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token) = setup_with_token(&env);
+    let owner = Address::generate(&env);
+    client.set_fee(&admin, &Some(token.clone()), &1u128, &0u128, &admin);
+    let project_id = create_test_project(&client, &owner, "SmallFeeProject");
+    mint_token(&env, &token, &owner, 1);
+    client.pay_fee(&owner, &project_id, &Some(token.clone()));
+    assert!(client.is_fee_paid(&project_id));
+}
+
+// ─── Max valid fee (i128::MAX) ───────────────────────────────────────────────
+
+#[test]
+fn test_max_valid_fee_i128_max_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token) = setup_with_token(&env);
+    let owner = Address::generate(&env);
+    let max_fee = i128::MAX as u128;
+    client.set_fee(&admin, &Some(token.clone()), &max_fee, &0u128, &admin);
+    let project_id = create_test_project(&client, &owner, "MaxFeeProject");
+    mint_token(&env, &token, &owner, i128::MAX);
+    client.pay_fee(&owner, &project_id, &Some(token.clone()));
+    assert!(client.is_fee_paid(&project_id));
+}
+
+// ─── Fee exceeding i128::MAX must be rejected before transfer ────────────────
+
+#[test]
+fn test_fee_exceeding_i128_max_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token) = setup_with_token(&env);
+    let owner = Address::generate(&env);
+    let overflow_fee = (i128::MAX as u128).saturating_add(1);
+    client.set_fee(&admin, &Some(token.clone()), &overflow_fee, &0u128, &admin);
+    let project_id = create_test_project(&client, &owner, "OverflowFeeProject");
+    // No tokens minted — the guard must fire before the transfer is attempted.
+    let result = client.try_pay_fee(&owner, &project_id, &Some(token.clone()));
+    assert_eq!(result, Err(Ok(ContractError::InvalidProjectData)));
+    // Fee must NOT be marked as paid.
+    assert!(!client.is_fee_paid(&project_id));
+}
+
+// ─── Registration fee boundary ───────────────────────────────────────────────
+
+#[test]
+fn test_registration_fee_exceeding_i128_max_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token) = setup_with_token(&env);
+    let overflow_fee = (i128::MAX as u128).saturating_add(1);
+    client.set_fee(&admin, &Some(token.clone()), &0u128, &overflow_fee, &admin);
+    let payer = Address::generate(&env);
+    let result = client.try_pay_registration_fee(&payer, &Some(token.clone()));
+    assert_eq!(result, Err(Ok(ContractError::InvalidProjectData)));
+}

--- a/dongle-smartcontract/src/tests/mod.rs
+++ b/dongle-smartcontract/src/tests/mod.rs
@@ -47,6 +47,10 @@ mod invariants;
 
 // Property-based pagination tests using proptest
 mod proptest_pagination;
+// Issue #221: fee amount boundary tests
+mod fee_boundary;
+// Issues #240, #241, #246: review tombstones, sorting, cooldown
+mod review_features;
 
 // Test infrastructure
 mod bookmarks;

--- a/dongle-smartcontract/src/tests/review_features.rs
+++ b/dongle-smartcontract/src/tests/review_features.rs
@@ -1,0 +1,163 @@
+//! Tests for review update cooldown (#246) and delete tombstones (#240).
+
+use crate::errors::ContractError;
+use crate::tests::fixtures::{create_test_project, setup_contract};
+use crate::types::ReviewSortMode;
+use crate::DongleContractClient;
+use soroban_sdk::{testutils::{Address as _, Ledger as _}, Address, Env};
+
+fn setup(env: &Env) -> (DongleContractClient<'_>, Address) {
+    setup_contract(env)
+}
+
+// ─── Cooldown (#246) ─────────────────────────────────────────────────────────
+
+#[test]
+fn test_immediate_review_update_fails_with_cooldown() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+    let project_id = create_test_project(&client, &admin, "CooldownProject");
+    let reviewer = Address::generate(&env);
+    client.add_review(&project_id, &reviewer, &3, &None);
+
+    // First update succeeds (no previous update timestamp stored).
+    client.update_review(&project_id, &reviewer, &4, &None);
+
+    // Immediate second update must fail — cooldown not elapsed.
+    let result = client.try_update_review(&project_id, &reviewer, &5, &None);
+    assert_eq!(result, Err(Ok(ContractError::InvalidStatus)));
+}
+
+#[test]
+fn test_review_update_succeeds_after_cooldown() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+    let project_id = create_test_project(&client, &admin, "CooldownPassedProject");
+    let reviewer = Address::generate(&env);
+    client.add_review(&project_id, &reviewer, &3, &None);
+
+    // First update records the cooldown timestamp.
+    client.update_review(&project_id, &reviewer, &4, &None);
+
+    // Advance ledger time past the cooldown window (3601 seconds > 3600s cooldown).
+    env.ledger().with_mut(|l| {
+        l.timestamp += 3601;
+    });
+
+    // Update after cooldown must succeed.
+    client.update_review(&project_id, &reviewer, &5, &None);
+    let review = client.get_review(&project_id, &reviewer).unwrap();
+    assert_eq!(review.rating, 5);
+}
+
+#[test]
+fn test_first_update_always_succeeds_no_previous_timestamp() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+    let project_id = create_test_project(&client, &admin, "FirstUpdateProject");
+    let reviewer = Address::generate(&env);
+    client.add_review(&project_id, &reviewer, &2, &None);
+
+    // No prior update timestamp — first update must always succeed.
+    client.update_review(&project_id, &reviewer, &3, &None);
+    let review = client.get_review(&project_id, &reviewer).unwrap();
+    assert_eq!(review.rating, 3);
+}
+
+// ─── Tombstones (#240) ───────────────────────────────────────────────────────
+
+#[test]
+fn test_delete_review_leaves_tombstone() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+    let project_id = create_test_project(&client, &admin, "TombstoneProject");
+    let reviewer = Address::generate(&env);
+    client.add_review(&project_id, &reviewer, &4, &None);
+
+    // Review exists; no tombstone yet.
+    assert!(client.get_review(&project_id, &reviewer).is_some());
+    assert!(client.get_review_tombstone(&project_id, &reviewer).is_none());
+
+    client.delete_review(&project_id, &reviewer);
+
+    // Review gone; tombstone present.
+    assert!(client.get_review(&project_id, &reviewer).is_none());
+    let tombstone = client.get_review_tombstone(&project_id, &reviewer).unwrap();
+    assert_eq!(tombstone.project_id, project_id);
+    assert_eq!(tombstone.reviewer, reviewer);
+}
+
+#[test]
+fn test_admin_delete_review_leaves_tombstone() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+    let project_id = create_test_project(&client, &admin, "AdminTombstoneProject");
+    let reviewer = Address::generate(&env);
+    client.add_review(&project_id, &reviewer, &3, &None);
+
+    client.admin_delete_review(&project_id, &reviewer, &admin);
+
+    assert!(client.get_review(&project_id, &reviewer).is_none());
+    assert!(client.get_review_tombstone(&project_id, &reviewer).is_some());
+}
+
+#[test]
+fn test_tombstone_not_present_for_never_reviewed() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+    let project_id = create_test_project(&client, &admin, "NoReviewProject");
+    let stranger = Address::generate(&env);
+
+    // Neither a review nor a tombstone should exist.
+    assert!(client.get_review(&project_id, &stranger).is_none());
+    assert!(client.get_review_tombstone(&project_id, &stranger).is_none());
+}
+
+// ─── Sorting (#241) ──────────────────────────────────────────────────────────
+
+#[test]
+fn test_list_reviews_sorted_newest_first() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+    let project_id = create_test_project(&client, &admin, "SortNewestProject");
+
+    let r1 = Address::generate(&env);
+    let r2 = Address::generate(&env);
+    client.add_review(&project_id, &r1, &3, &None);
+    env.ledger().with_mut(|l| l.timestamp += 100);
+    client.add_review(&project_id, &r2, &5, &None);
+
+    let reviews = client.list_reviews_sorted(&project_id, &0, &10, &ReviewSortMode::Newest);
+    assert_eq!(reviews.len(), 2);
+    // r2 was added later, so created_at is higher — should come first.
+    assert_eq!(reviews.get(0).unwrap().reviewer, r2);
+    assert_eq!(reviews.get(1).unwrap().reviewer, r1);
+}
+
+#[test]
+fn test_list_reviews_sorted_rating_high_to_low() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+    let project_id = create_test_project(&client, &admin, "SortRatingProject");
+
+    let r1 = Address::generate(&env);
+    let r2 = Address::generate(&env);
+    let r3 = Address::generate(&env);
+    client.add_review(&project_id, &r1, &2, &None);
+    client.add_review(&project_id, &r2, &5, &None);
+    client.add_review(&project_id, &r3, &3, &None);
+
+    let reviews = client.list_reviews_sorted(&project_id, &0, &10, &ReviewSortMode::RatingHigh);
+    assert_eq!(reviews.len(), 3);
+    assert_eq!(reviews.get(0).unwrap().rating, 5);
+    assert_eq!(reviews.get(1).unwrap().rating, 3);
+    assert_eq!(reviews.get(2).unwrap().rating, 2);
+}

--- a/dongle-smartcontract/src/types.rs
+++ b/dongle-smartcontract/src/types.rs
@@ -471,3 +471,28 @@ pub struct AdminProposal {
     pub status: ProposalStatus,
     pub created_at: u64,
 }
+
+/// Tombstone stored when a review is deleted so indexers can distinguish
+/// deleted reviews from reviews that never existed.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReviewTombstone {
+    pub project_id: u64,
+    pub reviewer: Address,
+    pub deleted_at: u64,
+}
+
+/// Sort order for `list_reviews_sorted`. Sorting is performed on-chain in-memory.
+/// For large projects this increases compute budget usage proportionally to review count.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ReviewSortMode {
+    /// Newest reviews first (highest created_at).
+    Newest,
+    /// Oldest reviews first (lowest created_at).
+    Oldest,
+    /// Highest rating first.
+    RatingHigh,
+    /// Lowest rating first.
+    RatingLow,
+}


### PR DESCRIPTION
Closes #221
Closes #240
Closes #241
Closes #246

## Summary
- Added `i128::MAX` boundary validation for fee amounts in both `pay_fee` and `pay_registration_fee` — rejects values that would overflow a silent cast to `i128` before any token transfer is attempted
- Added review delete tombstones (`ReviewTombstone` struct + `ExtensionKey::ReviewTombstone`) stored on reviewer and admin delete, so indexers can distinguish deleted reviews from never-existed ones
- Added `list_reviews_sorted` with four sort modes: `Newest`, `Oldest`, `RatingHigh`, `RatingLow` (on-chain in-memory bubble sort; cost scales linearly with review count — documented in method comment)
- Added configurable update cooldown (`REVIEW_UPDATE_COOLDOWN_SECONDS = 3600`): rejects a second update within the cooldown window using `ContractError::InvalidStatus` (dedicated variant deferred to a future refactor because `#[contracterror]` is at its 50-variant SDK 22 limit)
- Added `fee_boundary` and `review_features` test modules