### PR TITLE
Add language metadata schema fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,11 @@ Projects may attach extended off-chain metadata via `metadata_cid` (IPFS). Docum
 
 **Recommended optional fields:** `description`, `website`, `repository`, `documentation`, `logo`, `banner`, `categories`, `tags`, `socials`, `licenses`, `maintainers`, `createdAt`, `updatedAt`
 
+**Language metadata:** Use `language` for the primary metadata language and
+`supportedLanguages` for localized UI, documentation, or community materials.
+Review CID documents also support `language`; see
+[`docs/LANGUAGE_METADATA.md`](./docs/LANGUAGE_METADATA.md).
+
 **Backward compatibility:** Legacy documents that only include `security_contact` (see schema) remain valid. Indexers should treat unknown fields as opaque when validating against older versions.
 
 **Best practices:**
@@ -376,6 +381,7 @@ Dongle promotes:
 - [THREAT_MODEL.md](THREAT_MODEL.md) - Security threat model and mitigation reference
 - [review-cid.schema.json](review-cid.schema.json) - Off-chain JSON schema for review content CIDs
 - [review-cid.example.json](review-cid.example.json) - Valid off-chain JSON review example
+- [Language Metadata Guide](docs/LANGUAGE_METADATA.md) - Project and review language-code format guidance
 - [Storage Schema Reference](docs/STORAGE_SCHEMA.md) — canonical storage keys, read/write mapping, index consistency rules, and migration guidance.
 - [Soroban Documentation](https://soroban.stellar.org/docs)
 - [Stellar Developer Portal](https://developers.stellar.org/)

--- a/docs/LANGUAGE_METADATA.md
+++ b/docs/LANGUAGE_METADATA.md
@@ -1,0 +1,62 @@
+# Language Metadata
+
+Dongle metadata documents can expose language information off-chain so
+frontends and indexers can filter projects and reviews by locale without adding
+new on-chain storage.
+
+## Project Metadata
+
+Use `language` for the primary language of the project metadata document. Use
+`supportedLanguages` for the languages a project supports in its UI,
+documentation, or community materials.
+
+```json
+{
+  "language": "en",
+  "supportedLanguages": ["en", "es", "fr", "pt-BR"]
+}
+```
+
+## Review Metadata
+
+Use `language` on review CID documents for the language of the review text.
+
+```json
+{
+  "version": "1.0.0",
+  "text": "Tres bon projet.",
+  "language": "fr"
+}
+```
+
+## Accepted Format
+
+Language values use a conservative BCP 47-compatible pattern:
+
+```text
+^[a-z]{2,3}(-[A-Za-z0-9]{2,8})*$
+```
+
+Accepted examples:
+
+- `en`
+- `fr`
+- `es`
+- `pt-BR`
+- `zh-Hant`
+- `sr-Latn-RS`
+
+Rejected examples:
+
+- `EN`
+- `english`
+- `pt_BR`
+- `fr-`
+- `x`
+
+## Privacy And Indexing Notes
+
+Language metadata should describe the content language only. Do not infer or
+publish a reviewer's nationality, location, or identity from language choice.
+Indexers should treat missing language values as unknown and should not reject
+legacy metadata documents that predate these fields.

--- a/project-metadata.example.json
+++ b/project-metadata.example.json
@@ -2,6 +2,8 @@
   "version": "1.0.0",
   "projectName": "Dongle DeFi Explorer",
   "description": "A discovery layer and analytics dashboard for Stellar DeFi protocols. This extended description complements the on-chain summary stored in the contract.",
+  "language": "en",
+  "supportedLanguages": ["en", "es", "fr", "pt-BR"],
   "website": "https://dongle.example",
   "repository": "https://github.com/HubDApp/Dongle-Smartcontract",
   "documentation": "https://github.com/HubDApp/Dongle-Smartcontract/blob/main/README.md",

--- a/project-metadata.schema.json
+++ b/project-metadata.schema.json
@@ -23,6 +23,23 @@
       "maxLength": 4096,
       "description": "Extended markdown or plain-text description beyond the on-chain summary."
     },
+    "language": {
+      "type": "string",
+      "description": "Primary language for project metadata text, using an ISO 639 language code or BCP 47 language tag.",
+      "pattern": "^[a-z]{2,3}(-[A-Za-z0-9]{2,8})*$",
+      "examples": ["en", "fr", "pt-BR", "zh-Hant"]
+    },
+    "supportedLanguages": {
+      "type": "array",
+      "description": "Languages the project supports in its UI, documentation, or community materials.",
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z]{2,3}(-[A-Za-z0-9]{2,8})*$"
+      },
+      "uniqueItems": true,
+      "maxItems": 25,
+      "examples": [["en", "es", "fr", "pt-BR"]]
+    },
     "website": {
       "type": "string",
       "format": "uri",

--- a/review-cid.schema.json
+++ b/review-cid.schema.json
@@ -22,8 +22,9 @@
     },
     "language": {
       "type": "string",
-      "description": "The ISO 639-1 language code or BCP 47 tag of the review text",
-      "pattern": "^[a-z]{2}(-[A-Z]{2})?$"
+      "description": "The ISO 639 language code or BCP 47 language tag of the review text",
+      "pattern": "^[a-z]{2,3}(-[A-Za-z0-9]{2,8})*$",
+      "examples": ["en", "fr", "pt-BR", "zh-Hant"]
     },
     "attachments": {
       "type": "array",


### PR DESCRIPTION
Closes #237.

## Summary
- Add `language` and `supportedLanguages` to `project-metadata.schema.json`.
- Extend `project-metadata.example.json` with project language metadata.
- Tighten `review-cid.schema.json` language metadata to a BCP 47-compatible pattern with examples.
- Add `docs/LANGUAGE_METADATA.md` with accepted/rejected language-tag examples and privacy/indexing guidance.
- Link the language metadata guide from the root README.

## Validation
- Parsed `project-metadata.schema.json`, `project-metadata.example.json`, `review-cid.schema.json`, and `review-cid.example.json` with PowerShell `ConvertFrom-Json`.
- Checked accepted language tags: `en`, `fr`, `es`, `pt-BR`, `zh-Hant`, `sr-Latn-RS`.
- Checked rejected language tags: `EN`, `english`, `pt_BR`, `fr-`, `x`.
- `git diff --check`.