### PR TITLE
fix(types): remove unused CreateCollectionParams dead code

### DIFF
--- a/dongle-smartcontract/src/types.rs
+++ b/dongle-smartcontract/src/types.rs
@@ -358,14 +358,6 @@ pub struct Collection {
     pub updated_at: u64,
 }
 
-/// Parameters for creating a new collection (admin-only).
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct CreateCollectionParams {
-    pub name: String,
-    pub description: String,
-}
-
 /// Types of admin actions recorded in the admin action log.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -444,7 +436,7 @@ pub struct AdminActionEntry {
     pub reason_cid: Option<String>,
 }
 
-// ── Admin Timelock ──────────────────────────────────────────────────────────
+// ── Admin Timelock ───────────────────────────────────────────────────────────
 
 /// A scheduled action in the admin timelock.
 #[contracttype]


### PR DESCRIPTION
## Summary
Removes the dead `CreateCollectionParams` struct from `src/types.rs`.

## Problem
`CreateCollectionParams` (lines ~364-370) was defined but never referenced anywhere in the codebase. The `create_collection` function in `collection_registry.rs` takes `name: String` and `description: String` as separate arguments, making this struct entirely unused.

## Changes
- **Deleted** `CreateCollectionParams` struct and its doc comment from `src/types.rs`

## Note
`cargo build` currently fails due to an unrelated pre-existing unclosed delimiter error in `src/utils.rs` (line 365). This is outside the scope of issue #322 and was not introduced by this change.

Closes #322