### PR TITLE
#324 FeeRefundRecord type and its storage key are unused scaffolding …

### DIFF
--- a/dongle-smartcontract/src/storage_keys.rs
+++ b/dongle-smartcontract/src/storage_keys.rs
@@ -142,8 +142,6 @@ pub enum ExtensionKey {
     ProjectEndorsements(u64),
     /// Endorsement count for a project.
     EndorsementCount(u64),
-    /// Fee refund record keyed by verification request_id.
-    FeeRefundRecord(u64),
     /// Fee config history entry count.
     FeeConfigHistoryCount,
     /// Fee config history entry by index (oldest = 0).

--- a/dongle-smartcontract/src/types.rs
+++ b/dongle-smartcontract/src/types.rs
@@ -276,16 +276,6 @@ pub struct FeePaymentRecord {
     pub token: Option<Address>,
 }
 
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct FeeRefundRecord {
-    pub request_id: u64,
-    pub project_id: u64,
-    pub payer: Address,
-    pub token: Option<Address>,
-    pub amount: u128,
-    pub refunded: bool,
-}
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION
Findings:
The codebase contained dead/unused scaffolding for a planned but never-implemented fee-refund feature.
Two definitions were identified that were never used anywhere in the contract:
FeeRefundRecord struct in types.rs
ExtensionKey::FeeRefundRecord(u64) variant in storage_keys.rs
Fix Features Applied:

Completely removed the unused FeeRefundRecord struct definition.
Completely removed the unused FeeRefundRecord(u64) variant from the ExtensionKey enum.
Result: Clean removal of dead schema with no impact on any existing functionality.
Benefits of the Fix:

Eliminates dead code
Reduces contract size
Prevents future confusion from unused storage types
Keeps the codebase maintainable and clean

CLOSE #324 
