### PR TITLE
refactor: remove unused DataKey enum from types.rs

### DIFF
--- a/dongle-smartcontract/src/types.rs
+++ b/dongle-smartcontract/src/types.rs
@@ -198,23 +198,7 @@ pub struct ProjectReport {
     pub timestamp: u64,
 }
 
-#[contracttype]
-pub enum DataKey {
-    Project(u64),
-    ProjectCount,
-    OwnerProjects(Address),
-    Review(u64, Address),
-    UserReviews(Address),
-    Verification(u64),
-    NextProjectId,
-    Admin(Address),
-    FeeConfig,
-    Treasury,
-    ProjectStats(u64),
-    FeePaidForProject(u64),
-    ContractClaim(u64, String),
-    ProjectContracts(u64),
-}
+
 
 #[contracttype]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]


### PR DESCRIPTION
## Description

This PR removes the `DataKey` enum from `dongle-smartcontract/src/types.rs`, which was identified as unused dead code. 

The `DataKey` enum duplicated the purpose of the `StorageKey` and `ExtensionKey` implementations found in `storage_keys.rs` and appeared to be an abandoned earlier design. We've verified that there are zero references to it anywhere in the crate (including tests), making it perfectly safe to remove.

## Changes Made
- Deleted the unused `DataKey` enum from `src/types.rs`.

## Related Issues
Closes #321

## Type of Change
- [x] 🧹 Chore / Refactor (Dead code removal)
