### PR TITLE
refactor: extract shared pagination helper from duplicated boilerplate

### DIFF
--- a/dongle-smartcontract/src/collection_registry.rs
+++ b/dongle-smartcontract/src/collection_registry.rs
@@ -10,6 +10,7 @@ use crate::events::{
     publish_collection_updated_event, publish_project_added_to_collection_event,
     publish_project_removed_from_collection_event,
 };
+use crate::pagination::paginate;
 use crate::storage_keys::StorageKey;
 use crate::types::{AdminActionType, Collection};
 use soroban_sdk::{Address, Env, String, Vec};
@@ -288,28 +289,17 @@ impl CollectionRegistry {
             .persistent()
             .get(&StorageKey::CollectionList)
             .unwrap_or(Vec::new(env));
-
-        let limit = limit.min(100);
+        let page_ids = paginate(env, &ids, start, limit);
         let mut result = Vec::new(env);
-        let mut count = 0u32;
-
-        for (i, collection_id) in ids.iter().enumerate() {
-            if (i as u32) < start {
-                continue;
-            }
-            if count >= limit {
-                break;
-            }
+        for collection_id in page_ids.iter() {
             if let Some(collection) = env
                 .storage()
                 .persistent()
                 .get::<_, Collection>(&StorageKey::Collection(collection_id))
             {
                 result.push_back(collection);
-                count += 1;
             }
         }
-
         result
     }
 
@@ -324,23 +314,7 @@ impl CollectionRegistry {
             .persistent()
             .get(&StorageKey::CollectionProjectIds(collection_id))
             .unwrap_or(Vec::new(env));
-
-        let limit = limit.min(100);
-        let mut result = Vec::new(env);
-        let mut count = 0u32;
-
-        for (i, project_id) in ids.iter().enumerate() {
-            if (i as u32) < start {
-                continue;
-            }
-            if count >= limit {
-                break;
-            }
-            result.push_back(project_id);
-            count += 1;
-        }
-
-        result
+        paginate(env, &ids, start, limit)
     }
 
     pub fn get_collection_project_count(env: &Env, collection_id: u64) -> u32 {

--- a/dongle-smartcontract/src/featured_registry.rs
+++ b/dongle-smartcontract/src/featured_registry.rs
@@ -4,6 +4,7 @@ use crate::admin_action_log::AdminActionLog;
 use crate::auth::require_admin_auth;
 use crate::errors::ContractError;
 use crate::events::publish_featured_project_event;
+use crate::pagination::paginate;
 use crate::storage_keys::StorageKey;
 use crate::types::{AdminActionType, Project};
 use soroban_sdk::{Address, Env, Vec};
@@ -73,28 +74,17 @@ impl FeaturedRegistry {
             .persistent()
             .get(&StorageKey::FeaturedProjects)
             .unwrap_or(Vec::new(env));
-
-        let limit = limit.min(100);
+        let page_ids = paginate(env, &ids, start, limit);
         let mut result = Vec::new(env);
-        let mut count = 0u32;
-
-        for (i, project_id) in ids.iter().enumerate() {
-            if (i as u32) < start {
-                continue;
-            }
-            if count >= limit {
-                break;
-            }
+        for project_id in page_ids.iter() {
             if let Some(project) = env
                 .storage()
                 .persistent()
                 .get(&StorageKey::Project(project_id))
             {
                 result.push_back(project);
-                count += 1;
             }
         }
-
         result
     }
 }

--- a/dongle-smartcontract/src/lib.rs
+++ b/dongle-smartcontract/src/lib.rs
@@ -3,6 +3,7 @@
 
 mod admin_action_log;
 mod admin_manager;
+pub mod pagination;
 pub mod auth;
 mod bookmark_registry;
 mod collection_registry;

--- a/dongle-smartcontract/src/pagination.rs
+++ b/dongle-smartcontract/src/pagination.rs
@@ -1,0 +1,20 @@
+use soroban_sdk::{Env, Vec};
+
+const MAX_PAGE_LIMIT: u32 = 100;
+
+pub fn paginate<T: Clone>(env: &Env, items: &Vec<T>, start: u32, limit: u32) -> Vec<T> {
+    let limit = limit.min(MAX_PAGE_LIMIT);
+    let mut result = Vec::new(env);
+    let mut count = 0u32;
+    for (i, item) in items.iter().enumerate() {
+        if (i as u32) < start {
+            continue;
+        }
+        if count >= limit {
+            break;
+        }
+        result.push_back(item);
+        count += 1;
+    }
+    result
+}


### PR DESCRIPTION
## Summary

Extracts the duplicated "clamp limit, skip start, break at count" pagination loop into a shared generic `paginate()` function in a new `pagination.rs` module.

## Changes

- **New** `dongle-smartcontract/src/pagination.rs` — generic `paginate<T: Clone>(env, items, start, limit) -> Vec<T>` with `MAX_PAGE_LIMIT = 100`
- **Updated** `lib.rs` — added `pub mod pagination;`
- **Updated** `featured_registry.rs` — `list_featured_projects` now calls `paginate()` on IDs, then looks up projects
- **Updated** `collection_registry.rs` — both `list_collections` and `list_collection_projects` now call `paginate()`

## What was removed

~30 lines of identical pagination boilerplate across 3 functions, replaced with 3 one-line `paginate()` calls.

Fixes #336