### PR TITLE
fix: add length guard in dependency_key external_contract branch

### DIFF
--- a/dongle-smartcontract/src/dependency_registry.rs
+++ b/dongle-smartcontract/src/dependency_registry.rs
@@ -123,7 +123,10 @@ impl DependencyRegistry {
             return Ok(String::from_str(env, key_str));
         }
         if let Some(contract) = &dep.external_contract {
-            // Contract addresses are always 56 chars; "CTR:" prefix ensures no collision.
+            // Contract addresses must be exactly 56 chars; "CTR:" prefix ensures no collision.
+            if contract.len() != 56 {
+                return Err(ContractError::InvalidProjectData);
+            }
             let mut buf = [0u8; 4 + 56];
             buf[0..4].copy_from_slice(b"CTR:");
             contract.copy_into_slice(&mut buf[4..60]);


### PR DESCRIPTION
copy_into_slice panics if source and destination lengths differ. The external_contract branch assumed the address is always 56 chars and skipped the length check present in the CID and URL branches.

Add an explicit contract.len() != 56 check that returns ContractError::InvalidProjectData, matching the pattern already used for the CID and URL branches in the same function.


closes #410