### PR TITLE
fix: use shared MAX_PAGE_LIMIT constant instead of hardcoded 100 in pagination #353

### DIFF
--- a/dongle-smartcontract/src/pagination.rs
+++ b/dongle-smartcontract/src/pagination.rs
@@ -1,6 +1,5 @@
+use crate::constants::MAX_PAGE_LIMIT;
 use soroban_sdk::{Env, Vec};
-
-const MAX_PAGE_LIMIT: u32 = 100;
 
 pub fn paginate<T: Clone + soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val>>(
     env: &Env,


### PR DESCRIPTION
## Overview

The `paginate` function in `pagination.rs` had its own local `const MAX_PAGE_LIMIT: u32 = 100;` instead of referencing the shared constant from `crate::constants::MAX_PAGE_LIMIT`. If the constant is ever changed in `constants.rs`, the paginate function would silently keep the old cap.

Both `collection_registry.rs` and `featured_registry.rs` delegate their pagination to this function, so this single change fixes all the locations described in the issue.

## Related Issue

Closes #353

## Changes

- **`src/pagination.rs`**
  - Removed local `const MAX_PAGE_LIMIT: u32 = 100;`
  - Added `use crate::constants::MAX_PAGE_LIMIT;`
  - The `limit.min(MAX_PAGE_LIMIT)` call now references the shared constant

## Verification

- ✅ The `paginate` function now uses the shared `MAX_PAGE_LIMIT` from `constants.rs`
- ✅ No other hardcoded `limit.min(100)` patterns remain
- ✅ `collection_registry.rs` and `featured_registry.rs` paginate calls are now indirectly referencing the shared constant
- ✅ If `MAX_PAGE_LIMIT` is updated in `constants.rs`, the pagination cap updates automatically everywhere

## Acceptance Criteria

| Criteria | Status |
|----------|--------|
| Replace hardcoded `100` with `MAX_PAGE_LIMIT` in pagination path | ✅ |
| Import from `crate::constants::MAX_PAGE_LIMIT` | ✅ |
| All call sites (collection_registry, featured_registry via paginate) use shared constant | ✅ |