### PR TITLE
refactor: clarify pagination cursor semantics (#351)

### DIFF
--- a/CONTRACT_INTERFACE.md
+++ b/CONTRACT_INTERFACE.md
@@ -807,7 +807,7 @@ if let Some(hash) = get_project_integrity_hash(env, project_id) {
 **Parameters**:
 - `env` (Env): The contract environment
 - `sort_mode` (ProjectSortMode): The sorting mode (e.g., by rating, by name)
-- `start_id` (u64): The starting project ID for pagination
+- `start_index` (u64): Zero-based index into the sorted result for pagination
 - `limit` (u32): Maximum number of projects to return
 
 **Return Value**: `Vec<Project>`
@@ -859,7 +859,7 @@ let verified_projects = list_projects_by_status(env, VerificationStatus::Verifie
 **Parameters**:
 - `env` (Env): The contract environment
 - `category` (String): The category to filter by
-- `start_id` (u32): The starting index for pagination
+- `start_index` (u32): Zero-based index into the category's project ID list for pagination
 - `limit` (u32): Maximum number of projects to return
 
 **Return Value**: `Vec<Project>`
@@ -885,7 +885,7 @@ let defi_projects = list_projects_by_category(env, String::from_slice(&env, "DeF
 **Parameters**:
 - `env` (Env): The contract environment
 - `tag` (String): The tag to filter by
-- `start_id` (u32): The starting index for pagination
+- `start_index` (u32): Zero-based offset into the project ID scan space for pagination
 - `limit` (u32): Maximum number of projects to return
 
 **Return Value**: `Vec<Project>`
@@ -2003,7 +2003,7 @@ let reviews = get_reviews_by_ids(env, vec![&env, (1, reviewer1), (1, reviewer2)]
 **Parameters**:
 - `env` (Env): The contract environment
 - `project_id` (u64): The project ID
-- `start_id` (u32): The starting index for pagination
+- `start_index` (u32): Zero-based index into the project's review list for pagination
 - `limit` (u32): Maximum number of reviews to return
 
 **Return Value**: `Vec<Review>`
@@ -2185,7 +2185,7 @@ if let Some(tombstone) = get_review_tombstone(env, project_id, reviewer_address)
 **Parameters**:
 - `env` (Env): The contract environment
 - `project_id` (u64): The project ID
-- `start_id` (u32): Starting index for pagination
+- `start_index` (u32): Zero-based index into the project's review list for pagination
 - `limit` (u32): Maximum reviews to return
 - `sort_mode` (ReviewSortMode): The sorting mode
 
@@ -4708,7 +4708,7 @@ if let Some(dispute) = get_duplicate_dispute(env, dispute_id) {
 
 1. **Always check return types**: Functions return `Result` or `Option` - handle both success and failure cases
 2. **Validate project ownership**: For owner-only operations, verify ownership before calling
-3. **Use pagination**: For list operations, use appropriate start_id/limit to avoid timeouts
+3. **Use pagination**: For list operations, use appropriate `start_id` (project ID cursor) or `start_index` (list offset) with `limit` to avoid timeouts
 4. **Cache project data**: Once retrieved, cache project data locally when possible
 5. **Monitor admin actions**: Regularly review admin action logs for compliance
 6. **Handle duplicates gracefully**: Use dispute resolution for duplicate detection

--- a/STORAGE_INDEXES.md
+++ b/STORAGE_INDEXES.md
@@ -14,7 +14,8 @@ All paginated list endpoints clamp `limit` to `MAX_PAGE_LIMIT` (**100**). When `
 |-----------|----------|
 | `limit = 0` | Treated as `MAX_PAGE_LIMIT` (100) on most endpoints |
 | `limit > 100` | Clamped to 100 |
-| `start` / `start_id` / `start_index` | Zero-based offset into the index Vec |
+| `start_id` | Project ID cursor (`list_projects`, `list_projects_by_status`) |
+| `start_index` | Zero-based offset into an index Vec or sorted result |
 
 Indexers should page through large indexes using these parameters rather than assuming a single call returns all entries.
 

--- a/dongle-smartcontract/README.md
+++ b/dongle-smartcontract/README.md
@@ -1463,7 +1463,7 @@ soroban contract invoke \
   --network testnet \
   -- list_projects_by_category \
   --category "DeFi" \
-  --start_id 0 \
+  --start_index 0 \
   --limit 10
 ```
 
@@ -1475,7 +1475,7 @@ soroban contract invoke \
   --network testnet \
   -- list_projects_by_tag \
   --tag "nft" \
-  --start_id 0 \
+  --start_index 0 \
   --limit 10
 ```
 

--- a/dongle-smartcontract/src/lib.rs
+++ b/dongle-smartcontract/src/lib.rs
@@ -321,19 +321,19 @@ impl DongleContract {
     pub fn list_projects_by_category(
         env: Env,
         category: String,
-        start_id: u32,
+        start_index: u32,
         limit: u32,
     ) -> Vec<Project> {
-        ProjectRegistry::list_projects_by_category(&env, category, start_id, limit)
+        ProjectRegistry::list_projects_by_category(&env, category, start_index, limit)
     }
 
     pub fn list_projects_sorted(
         env: Env,
         sort_mode: ProjectSortMode,
-        start_id: u64,
+        start_index: u64,
         limit: u32,
     ) -> Vec<Project> {
-        ProjectRegistry::list_projects_sorted(&env, sort_mode, start_id, limit)
+        ProjectRegistry::list_projects_sorted(&env, sort_mode, start_index, limit)
     }
 
     pub fn claim_contract_address(
@@ -497,8 +497,8 @@ impl DongleContract {
         ReviewRegistry::get_reviews_by_ids(&env, ids)
     }
 
-    pub fn list_reviews(env: Env, project_id: u64, start_id: u32, limit: u32) -> Vec<Review> {
-        ReviewRegistry::list_reviews(&env, project_id, start_id, limit)
+    pub fn list_reviews(env: Env, project_id: u64, start_index: u32, limit: u32) -> Vec<Review> {
+        ReviewRegistry::list_reviews(&env, project_id, start_index, limit)
     }
 
     pub fn get_project_stats(env: Env, project_id: u64) -> ProjectStats {
@@ -592,11 +592,11 @@ impl DongleContract {
     pub fn list_reviews_sorted(
         env: Env,
         project_id: u64,
-        start_id: u32,
+        start_index: u32,
         limit: u32,
         sort_mode: ReviewSortMode,
     ) -> Vec<Review> {
-        ReviewRegistry::list_reviews_sorted(&env, project_id, start_id, limit, sort_mode)
+        ReviewRegistry::list_reviews_sorted(&env, project_id, start_index, limit, sort_mode)
     }
 
     // --- Verification Registry ---
@@ -942,8 +942,8 @@ impl DongleContract {
     }
 
     /// List projects by tag - Issue #125
-    pub fn list_projects_by_tag(env: Env, tag: String, start_id: u32, limit: u32) -> Vec<Project> {
-        ProjectRegistry::list_projects_by_tag(&env, tag, start_id, limit)
+    pub fn list_projects_by_tag(env: Env, tag: String, start_index: u32, limit: u32) -> Vec<Project> {
+        ProjectRegistry::list_projects_by_tag(&env, tag, start_index, limit)
     }
 
     // --- Collection Registry ---

--- a/dongle-smartcontract/src/project_registry.rs
+++ b/dongle-smartcontract/src/project_registry.rs
@@ -936,7 +936,7 @@ impl ProjectRegistry {
     pub fn list_projects_by_category(
         env: &Env,
         category: String,
-        start_id: u32,
+        start_index: u32,
         limit: u32,
     ) -> Vec<Project> {
         let effective_limit = if limit == 0 || limit > MAX_PAGE_LIMIT {
@@ -953,14 +953,14 @@ impl ProjectRegistry {
 
         let mut projects = Vec::new(env);
         let len = category_projects.len();
-        if start_id >= len {
+        if start_index >= len {
             return projects;
         }
 
-        let end = core::cmp::min(start_id.saturating_add(effective_limit), len);
+        let end = core::cmp::min(start_index.saturating_add(effective_limit), len);
 
         let mut collected: u32 = 0;
-        for i in start_id..end {
+        for i in start_index..end {
             if collected >= effective_limit {
                 break;
             }
@@ -1173,7 +1173,7 @@ impl ProjectRegistry {
     }
 
     /// List projects by tag - Issue #125
-    pub fn list_projects_by_tag(env: &Env, tag: String, start_id: u32, limit: u32) -> Vec<Project> {
+    pub fn list_projects_by_tag(env: &Env, tag: String, start_index: u32, limit: u32) -> Vec<Project> {
         let effective_limit = if limit == 0 || limit > MAX_PAGE_LIMIT {
             MAX_PAGE_LIMIT
         } else {
@@ -1193,8 +1193,8 @@ impl ProjectRegistry {
 
         let mut collected: u32 = 0;
 
-        // Iterate through all projects; start_id is a 0-based offset into the project ID space.
-        for id in (start_id as u64 + 1)..=count {
+        // Iterate through all projects; start_index is a 0-based offset into the project ID space.
+        for id in (start_index as u64 + 1)..=count {
             if collected >= effective_limit {
                 break;
             }
@@ -1944,7 +1944,7 @@ impl ProjectRegistry {
     pub fn list_projects_sorted(
         env: &Env,
         sort_mode: ProjectSortMode,
-        start_id: u64,
+        start_index: u64,
         limit: u32,
     ) -> Vec<Project> {
         let effective_limit = if limit == 0 || limit > MAX_PAGE_LIMIT {
@@ -1988,7 +1988,7 @@ impl ProjectRegistry {
         let n = all.len();
 
         let mut result = Vec::new(env);
-        let start = start_id as u32;
+        let start = start_index as u32;
         if start < n {
             let end = core::cmp::min(start.saturating_add(effective_limit), n);
             for i in start..end {

--- a/dongle-smartcontract/src/review_registry.rs
+++ b/dongle-smartcontract/src/review_registry.rs
@@ -836,7 +836,7 @@ impl ReviewRegistry {
         out
     }
 
-    pub fn list_reviews(env: &Env, project_id: u64, start_id: u32, limit: u32) -> Vec<Review> {
+    pub fn list_reviews(env: &Env, project_id: u64, start_index: u32, limit: u32) -> Vec<Review> {
         // Enforce pagination limits: limit must be 1..=MAX_PAGE_LIMIT
         let effective_limit = if limit == 0 || limit > MAX_PAGE_LIMIT {
             MAX_PAGE_LIMIT
@@ -852,12 +852,12 @@ impl ReviewRegistry {
 
         let mut reviews = Vec::new(env);
         let len = reviewers.len();
-        if start_id >= len {
+        if start_index >= len {
             return reviews;
         }
-        let end = core::cmp::min(start_id.saturating_add(effective_limit), len);
+        let end = core::cmp::min(start_index.saturating_add(effective_limit), len);
 
-        for i in start_id..end {
+        for i in start_index..end {
             if let Some(reviewer) = reviewers.get(i) {
                 if let Some(review) = Self::get_review(env, project_id, reviewer) {
                     // Exclude hidden reviews from default listings
@@ -1136,7 +1136,7 @@ impl ReviewRegistry {
     pub fn list_reviews_sorted(
         env: &Env,
         project_id: u64,
-        start_id: u32,
+        start_index: u32,
         limit: u32,
         sort_mode: ReviewSortMode,
     ) -> Vec<Review> {
@@ -1175,11 +1175,11 @@ impl ReviewRegistry {
 
         // Apply pagination.
         let mut out = Vec::new(env);
-        if start_id >= n {
+        if start_index >= n {
             return out;
         }
-        let end = core::cmp::min(start_id.saturating_add(effective_limit), n);
-        for i in start_id..end {
+        let end = core::cmp::min(start_index.saturating_add(effective_limit), n);
+        for i in start_index..end {
             if let Some(review) = all.get(i) {
                 out.push_back(review);
             }

--- a/dongle-smartcontract/src/tests/pagination.rs
+++ b/dongle-smartcontract/src/tests/pagination.rs
@@ -232,11 +232,11 @@ fn test_list_reviews_basic_pagination() {
         .mock_all_auths()
         .add_review(&project_id, &reviewer3, &3, &None);
 
-    // First page: start=0, limit=2
+    // First page: start_index=0, limit=2
     let page1 = client.list_reviews(&project_id, &0, &2);
     assert_eq!(page1.len(), 2);
 
-    // Second page: start=2, limit=2
+    // Second page: start_index=2, limit=2
     let page2 = client.list_reviews(&project_id, &2, &2);
     assert_eq!(page2.len(), 1);
 }
@@ -290,7 +290,7 @@ fn test_list_reviews_start_beyond_count_returns_empty() {
         .mock_all_auths()
         .add_review(&project_id, &reviewer, &5, &None);
 
-    // start=100 is beyond the single review
+    // start_index=100 is beyond the single review
     let result = client.list_reviews(&project_id, &100, &10);
     assert_eq!(result.len(), 0);
 }
@@ -384,12 +384,12 @@ fn test_list_reviews_all_pages_cover_all_reviews() {
             .add_review(&project_id, &reviewer, &4, &None);
     }
 
-    // Collect all reviews via pagination
+    // Collect all reviews via pagination (start_index is a list offset, not a review ID)
     let mut all_reviews = soroban_sdk::Vec::new(&env);
-    let mut start = 0u32;
+    let mut start_index = 0u32;
     let page_size = 2u32;
     loop {
-        let page = client.list_reviews(&project_id, &start, &page_size);
+        let page = client.list_reviews(&project_id, &start_index, &page_size);
         let page_len = page.len();
         for r in page.iter() {
             all_reviews.push_back(r);
@@ -397,7 +397,7 @@ fn test_list_reviews_all_pages_cover_all_reviews() {
         if page_len < page_size {
             break;
         }
-        start += page_size;
+        start_index += page_size;
     }
 
     assert_eq!(


### PR DESCRIPTION
Closes #351

## Summary
- Reserve `start_id` for true project-ID cursors (`list_projects`, `list_projects_by_status`).
- Rename index/offset pagination parameters to `start_index` in:
  - `list_projects_by_category`
  - `list_projects_by_tag`
  - `list_projects_sorted`
  - `list_reviews`
  - `list_reviews_sorted`
- Updated `CONTRACT_INTERFACE.md`, `STORAGE_INDEXES.md`, README examples, and pagination test comments.

## Test plan
- [x] Pagination tests updated for `start_index` semantics
- [ ] `cargo test` pagination suite (CI)
- [ ] Verify no stale ambiguous `start_id` references remain in index-based APIs