### PR TITLE
#503 refactor: remove test output text files committed to dongle-smar…

### DIFF
--- a/dongle-smartcontract/.gitignore
+++ b/dongle-smartcontract/.gitignore
@@ -1,2 +1,26 @@
 target/
 test_snapshots/
+
+# Test/build output dumps (local artifacts; do not commit)
+check_output.txt
+errors.txt
+final_test_output.txt
+final_test_results.txt
+final_test_run.txt
+full_test_output.txt
+test_final.txt
+test_output.txt
+test_output_latest.txt
+
+# Common variants generated while capturing test/build output
+*_output.txt
+*_output_*.txt
+*_errors.txt
+build_error*.log
+build_errors*.log
+test_results*.txt
+test_build_errors*.txt
+final_test_*.txt
+full_test_*.txt
+test_final*.txt
+test_output*.txt


### PR DESCRIPTION
### Summary

This PR cleans up repository hygiene for the `dongle-smartcontract/` package by ensuring generated test/build output files are ignored by Git.

The issue described several local test output artifacts that should not be committed to version control, including files such as `check_output.txt`, `errors.txt`, `final_test_output.txt`, `test_output.txt`, and related test result dumps.

### Changes Made

Updated:

```text
dongle-smartcontract/.gitignore
```

Added ignore rules for the exact generated artifact files listed in the issue:

```gitignore
check_output.txt
errors.txt
final_test_output.txt
final_test_results.txt
final_test_run.txt
full_test_output.txt
test_final.txt
test_output.txt
test_output_latest.txt
```

Also added broader ignore patterns for common test/build output variants:

```gitignore
*_output.txt
*_output_*.txt
*_errors.txt
build_error*.log
build_errors*.log
test_results*.txt
test_build_errors*.txt
final_test_*.txt
full_test_*.txt
test_final*.txt
test_output*.txt
```

### Why This Change Is Needed

Generated test and build output files are local artifacts and should not be stored in version control. Keeping them ignored helps:

- Prevent accidental commits of local test logs
- Reduce repository noise
- Keep diffs focused on source and documentation changes
- Improve maintainability for contributors working inside `dongle-smartcontract/`

### Validation

I verified that the listed files are now ignored by Git when recreated locally:

```text
!! dongle-smartcontract/check_output.txt
!! dongle-smartcontract/errors.txt
!! dongle-smartcontract/final_test_output.txt
!! dongle-smartcontract/final_test_results.txt
!! dongle-smartcontract/final_test_run.txt
!! dongle-smartcontract/full_test_output.txt
!! dongle-smartcontract/test_final.txt
!! dongle-smartcontract/test_output.txt
!! dongle-smartcontract/test_output_latest.txt
```

The `!!` prefix confirms Git treats these files as ignored.

### Tests

Attempted to run:

```bash
cargo test
```

and:

```bash
make test
```

However, tests could not be executed in the current workspace because Rust/Cargo is not installed:

```text
cargo: command not found
```

This PR only modifies `.gitignore` and does not change contract source code, dependencies, build configuration, or tests, so it should not affect runtime or test behavior.

### Files Changed

```text
dongle-smartcontract/.gitignore
```

CLOSE #503 