### PR TITLE
ci: pin Rust toolchain in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.85.0
         with:
           components: rustfmt
 
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.85.0
         with:
           targets: wasm32-unknown-unknown
           components: clippy
@@ -52,7 +52,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-clippy-${{ hashFiles('Cargo.lock', 'dongle-smartcontract/Cargo.lock') }}
+          key: ${{ runner.os }}-clippy-${{ hashFiles('rust-toolchain.toml', 'Cargo.lock', 'dongle-smartcontract/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-clippy-
 
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.85.0
         with:
           targets: wasm32-unknown-unknown
 
@@ -77,7 +77,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-test-${{ hashFiles('Cargo.lock', 'dongle-smartcontract/Cargo.lock') }}
+          key: ${{ runner.os }}-test-${{ hashFiles('rust-toolchain.toml', 'Cargo.lock', 'dongle-smartcontract/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-test-
 
@@ -92,7 +92,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.85.0
         with:
           targets: wasm32-unknown-unknown
 
@@ -103,7 +103,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-build-${{ hashFiles('Cargo.lock', 'dongle-smartcontract/Cargo.lock') }}
+          key: ${{ runner.os }}-build-${{ hashFiles('rust-toolchain.toml', 'Cargo.lock', 'dongle-smartcontract/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-build-
 
@@ -118,7 +118,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.85.0
         with:
           targets: wasm32-unknown-unknown
 
@@ -130,7 +130,7 @@ jobs:
             ~/.cargo/git
             ~/.cargo/bin
             target
-          key: ${{ runner.os }}-optimize-${{ hashFiles('Cargo.lock', 'dongle-smartcontract/Cargo.lock') }}
+          key: ${{ runner.os }}-optimize-${{ hashFiles('rust-toolchain.toml', 'Cargo.lock', 'dongle-smartcontract/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-optimize-
 


### PR DESCRIPTION
## Summary

- Replace floating `dtolnay/rust-toolchain@stable` workflow installs with the pinned `dtolnay/rust-toolchain@1.85.0` ref that matches `rust-toolchain.toml`.
- Include `rust-toolchain.toml` in Rust cache keys so cache entries refresh when the pinned compiler changes.

## Why

The repository already has `rust-toolchain.toml` pinned to Rust `1.85.0`, but CI was still installing floating stable in every Rust job. This makes CI vulnerable to future stable compiler or Soroban dependency compatibility changes.

## Verification

- `git diff --check` passed.
- Verified the upstream action ref exists: `refs/heads/1.85.0`.
- Local `cargo` commands could not be run in this environment because Cargo is not installed.

Closes #514
