### PR TITLE
review revision

### DIFF
--- a/dongle-smartcontract/src/review_registry/storage.rs
+++ b/dongle-smartcontract/src/review_registry/storage.rs
@@ -404,7 +404,40 @@ impl ReviewRegistry {
             env.storage().persistent().set(&count_key, &new_count);
             revision_count
         } else {
-            revision_count.saturating_sub(1)
+            let start_idx = revision_count.saturating_sub(MAX_REVIEW_REVISIONS - 1);
+            for j in 0..(MAX_REVIEW_REVISIONS - 1) {
+                let src_idx = start_idx + j;
+                let from_key = ExtensionKey::ReviewRevision(project_id, reviewer.clone(), src_idx);
+                if let Some(mut rev) = env.storage().persistent().get::<_, ReviewRevision>(&from_key) {
+                    rev.revision_index = j;
+                    let to_key = ExtensionKey::ReviewRevision(project_id, reviewer.clone(), j);
+                    env.storage().persistent().set(&to_key, &rev);
+                }
+            }
+
+            let new_index = MAX_REVIEW_REVISIONS - 1;
+            env.storage().persistent().set(
+                &ExtensionKey::ReviewRevision(project_id, reviewer.clone(), new_index),
+                &ReviewRevision {
+                    revision_index: new_index,
+                    rating,
+                    content_cid,
+                    revised_at,
+                },
+            );
+            env.storage().persistent().set(&count_key, &MAX_REVIEW_REVISIONS);
+
+            if revision_count > MAX_REVIEW_REVISIONS {
+                for i in MAX_REVIEW_REVISIONS..revision_count {
+                    env.storage().persistent().remove(&ExtensionKey::ReviewRevision(
+                        project_id,
+                        reviewer.clone(),
+                        i,
+                    ));
+                }
+            }
+
+            new_index
         }
     }
 

--- a/dongle-smartcontract/src/tests/review_history.rs
+++ b/dongle-smartcontract/src/tests/review_history.rs
@@ -141,3 +141,38 @@ fn test_weighted_rating_formula_validation() {
     assert_eq!(RatingCalculator::calculate_average(2000, 4), 500);
     assert_eq!(RatingCalculator::calculate_weighted(2000, 4), 416);
 }
+
+#[test]
+fn test_review_revision_history_pruning_at_max_limit() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup_contract(&env);
+    let project_id = create_test_project(&client, &admin, "Prune-Revisions-Project");
+    let reviewer = Address::generate(&env);
+
+    let cid_base = String::from_str(&env, CID_V1);
+    client.submit_review(&project_id, &reviewer, &1, &cid_base);
+
+    // Perform 52 updates to exceed MAX_REVIEW_REVISIONS (50)
+    for i in 1..=52 {
+        env.ledger()
+            .set_timestamp(env.ledger().timestamp().saturating_add(3601));
+        let new_rating = (i % 5) + 1;
+        client.update_review(&project_id, &reviewer, &new_rating, &Some(cid_base.clone()));
+    }
+
+    let revision_count = client.get_review_revision_count(&project_id, &reviewer);
+    assert_eq!(revision_count, 50, "Revision count must be capped at 50");
+
+    let history = client.get_review_history(&project_id, &reviewer, &0, &100);
+    assert_eq!(history.len(), 50, "History length must not exceed 50");
+
+    // The first revision in history should have revision_index 0
+    let first = history.get(0).unwrap();
+    assert_eq!(first.revision_index, 0);
+
+    // The last revision in history should have revision_index 49
+    let last = history.get(49).unwrap();
+    assert_eq!(last.revision_index, 49);
+}
+

--- a/scripts/dongle-smartcontract/src/review_registry.rs
+++ b/scripts/dongle-smartcontract/src/review_registry.rs
@@ -317,7 +317,40 @@ impl ReviewRegistry {
             env.storage().persistent().set(&count_key, &new_count);
             revision_count
         } else {
-            revision_count.saturating_sub(1)
+            let start_idx = revision_count.saturating_sub(MAX_REVIEW_REVISIONS - 1);
+            for j in 0..(MAX_REVIEW_REVISIONS - 1) {
+                let src_idx = start_idx + j;
+                let from_key = ExtensionKey::ReviewRevision(project_id, reviewer.clone(), src_idx);
+                if let Some(mut rev) = env.storage().persistent().get::<_, ReviewRevision>(&from_key) {
+                    rev.revision_index = j;
+                    let to_key = ExtensionKey::ReviewRevision(project_id, reviewer.clone(), j);
+                    env.storage().persistent().set(&to_key, &rev);
+                }
+            }
+
+            let new_index = MAX_REVIEW_REVISIONS - 1;
+            env.storage().persistent().set(
+                &ExtensionKey::ReviewRevision(project_id, reviewer.clone(), new_index),
+                &ReviewRevision {
+                    revision_index: new_index,
+                    rating,
+                    content_cid,
+                    revised_at,
+                },
+            );
+            env.storage().persistent().set(&count_key, &MAX_REVIEW_REVISIONS);
+
+            if revision_count > MAX_REVIEW_REVISIONS {
+                for i in MAX_REVIEW_REVISIONS..revision_count {
+                    env.storage().persistent().remove(&ExtensionKey::ReviewRevision(
+                        project_id,
+                        reviewer.clone(),
+                        i,
+                    ));
+                }
+            }
+
+            new_index
         }
     }
 


### PR DESCRIPTION
Summary of Work
I have resolved issue [#534](https://github.com/Bamzy123/Dongle-Smartcontract/issues/534) on the review-revision branch:

Root Cause:

append_review_revision previously did not enforce pruning when revision_count >= MAX_REVIEW_REVISIONS (50). Instead, it entered an else block returning revision_count.saturating_sub(1) without writing new revisions or pruning old ones.
Changes Made:

Updated append_review_revision in 

storage.rs
 and 

review_registry.rs
 to implement FIFO pruning:
Shifts existing stored revisions down by 1 position (overwriting index 0).
Appends the new revision at index MAX_REVIEW_REVISIONS - 1 (49).
Caps ReviewRevisionCount at 50 and removes any excess legacy keys.
Added unit test test_review_revision_history_pruning_at_max_limit in 

review_history.rs
 to verify cap enforcement and history bounds after 50+ edits.

close #534