### PR TITLE
fix(project-registry): align invalid name test with error definitions

### DIFF
--- a/dongle-smartcontract/src/project_registry.rs
+++ b/dongle-smartcontract/src/project_registry.rs
@@ -2109,7 +2109,7 @@ mod tests {
         // 3. Validate alphanumeric, underscore, hyphen
         for c in name_str.chars() {
             if !c.is_ascii_alphanumeric() && c != '_' && c != '-' {
-                return Err(ContractError::InvalidNameFormat);
+                return Err(ContractError::InvalidProjectNameFormat);
             }
         }
 
@@ -2152,7 +2152,7 @@ mod tests {
             &String::from_str(&env, "Desc"),
             &String::from_str(&env, "Cat"),
         );
-        assert_eq!(result, Err(ContractError::InvalidNameFormat));
+        assert_eq!(result, Err(ContractError::InvalidProjectNameFormat));
     }
 
     #[test]

--- a/scripts/dongle-smartcontract/src/errors.rs
+++ b/scripts/dongle-smartcontract/src/errors.rs
@@ -84,6 +84,8 @@ pub enum ContractError {
 
     // Normalized name duplicate
     DuplicateProjectName = 60,
+    /// Legacy alias for invalid name format
+    InvalidNameFormat = 61,
 }
 
 pub type Error = ContractError;


### PR DESCRIPTION
SUMMARY
I updated the tests to use InvalidProjectNameFormat then i added InvalidNameFormat to the scripts copy of errors.rs so tests there compile

closes #464 