### PR TITLE
feat: add verification expiring soon query

### DIFF
--- a/docs/CONTRACT_INTERFACE.md
+++ b/docs/CONTRACT_INTERFACE.md
@@ -2514,6 +2514,22 @@ let history = get_verification_history(env, project_id);
 let expired = is_verification_expired(env, project_id)?;
 ```
 
+### `is_verification_expiring_soon`
+
+**Purpose**: Report whether a verification will expire within a caller-supplied renewal-warning threshold.
+
+**Parameters**:
+- `project_id` (u64): Project to inspect.
+- `threshold_seconds` (u64): Maximum remaining lifetime for the warning.
+
+**Returns**:
+- `true` when the verification has a nonzero expiry, is not already expired, and has at most `threshold_seconds` remaining.
+- `false` for no-expiry and already-expired records.
+
+```rust
+let expiring_soon = is_verification_expiring_soon(env, project_id, 2_592_000)?;
+```
+
 ---
 
 ### `clear_verification_history`

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -19,6 +19,7 @@ branches and contained error codes and behavior that no longer match `main`.
 | `get_renewal_request(project_id)` | Public | Returns the current pending request |
 | `get_renewal_history(project_id, start_index, limit)` | Public | Returns approved renewal records with pagination |
 | `is_verification_expired(project_id)` | Public | Reports whether a nonzero expiry is earlier than the current ledger time |
+| `is_verification_expiring_soon(project_id, threshold_seconds)` | Public | Reports whether a non-expired verification has `threshold_seconds` or less remaining |
 
 The entrypoints are defined in
 [`lib.rs`](../dongle-smartcontract/src/lib.rs), and the workflow is implemented
@@ -135,6 +136,12 @@ or beyond the stored count returns an empty vector.
 - `false` when `expires_at` is zero, which represents no expiry;
 - `false` while the current ledger timestamp is at or before the expiry; and
 - `true` only after the expiry timestamp has passed.
+
+`is_verification_expiring_soon` returns `true` only for an expiry-enabled,
+non-expired verification whose remaining lifetime is less than or equal to the
+supplied threshold. It returns `false` for records without an expiry and for
+already-expired records; callers should use `is_verification_expired` for the
+latter state.
 
 ## Errors
 

--- a/dongle-smartcontract/src/lib.rs
+++ b/dongle-smartcontract/src/lib.rs
@@ -739,6 +739,16 @@ impl DongleContract {
         VerificationRegistry::is_verification_expired(&env, project_id)
     }
 
+    /// Returns whether a non-expired verification will expire within the
+    /// supplied threshold. This is a read-only renewal-warning helper.
+    pub fn is_verification_expiring_soon(
+        env: Env,
+        project_id: u64,
+        threshold_seconds: u64,
+    ) -> Result<bool, ContractError> {
+        VerificationRegistry::is_verification_expiring_soon(&env, project_id, threshold_seconds)
+    }
+
     /// Admin: prune verification history, keeping the most recent `keep_count` records.
     /// Returns the number of records removed.
     pub fn clear_verification_history(

--- a/dongle-smartcontract/src/tests/renewal.rs
+++ b/dongle-smartcontract/src/tests/renewal.rs
@@ -398,6 +398,7 @@ fn test_is_verification_expired_no_expiry() {
     // Check expiry (should be false since expires_at = 0)
     let is_expired = client.is_verification_expired(&project_id);
     assert_eq!(is_expired, false);
+    assert_eq!(client.is_verification_expiring_soon(&project_id, &u64::MAX), false);
 }
 
 // ---------------------------------------------------------------------------

--- a/dongle-smartcontract/src/tests/verification_features.rs
+++ b/dongle-smartcontract/src/tests/verification_features.rs
@@ -97,8 +97,16 @@ fn test_verification_expiry_and_duration() {
     // Check if it is expired at timestamp 500 (should be false)
     env.ledger().set_timestamp(500);
     assert!(!client.is_verification_expired(&project_id));
+    assert!(client.is_verification_expiring_soon(&project_id, &600));
+    assert!(!client.is_verification_expiring_soon(&project_id, &599));
+
+    // At the exact expiry timestamp, the verification is still not expired
+    // and a zero-second threshold correctly reports the renewal boundary.
+    env.ledger().set_timestamp(1100);
+    assert!(client.is_verification_expiring_soon(&project_id, &0));
 
     // Check if it is expired at timestamp 1200 (should be true)
     env.ledger().set_timestamp(1200);
     assert!(client.is_verification_expired(&project_id));
+    assert!(!client.is_verification_expiring_soon(&project_id, &u64::MAX));
 }

--- a/dongle-smartcontract/src/verification_registry/storage.rs
+++ b/dongle-smartcontract/src/verification_registry/storage.rs
@@ -843,6 +843,27 @@ impl VerificationRegistry {
         Ok(verification.expires_at != 0 && env.ledger().timestamp() > verification.expires_at)
     }
 
+    /// Returns true when a verification will expire within `threshold_seconds`.
+    ///
+    /// Records with `expires_at == 0` never expire. Already-expired records
+    /// return false so callers can distinguish a renewal warning from an
+    /// expired-verification state via `is_verification_expired`.
+    pub fn is_verification_expiring_soon(
+        env: &Env,
+        project_id: u64,
+        threshold_seconds: u64,
+    ) -> Result<bool, ContractError> {
+        let verification = Self::get_verification(env, project_id)
+            .ok_or(ContractError::VerificationNotFound)?;
+        let now = env.ledger().timestamp();
+
+        Ok(
+            verification.expires_at != 0
+                && now <= verification.expires_at
+                && verification.expires_at.saturating_sub(now) <= threshold_seconds,
+        )
+    }
+
     /// Admin-only: prune verification history for a project, retaining only the
     /// most recent `keep_count` records. Pass `keep_count = 0` to remove all
     /// historical records (the live `Verification(project_id)` record is never removed).


### PR DESCRIPTION
## Summary

Adds `is_verification_expiring_soon(project_id, threshold_seconds)` to let frontends warn project owners before verification expires.

- Returns `true` only when a verification has a configured expiry, is not already expired, and has at most `threshold_seconds` remaining.
- Returns `false` for permanent/no-expiry verifications and already-expired verifications.
- Keeps `is_verification_expired` as the authoritative expired-state query.
- Adds boundary coverage for inside/outside threshold, exact expiry, expired records, and no-expiry records.
- Updates contract interface and verification documentation.

Closes #520