### PR TITLE
fix: proposal counter starts at 0 to eliminate ID gap in create_proposal

### DIFF
--- a/dongle-smartcontract/src/admin_manager.rs
+++ b/dongle-smartcontract/src/admin_manager.rs
@@ -245,7 +245,7 @@ impl AdminManager {
             .storage()
             .persistent()
             .get(&crate::storage_keys::ExtensionKey::NextAdminProposalId)
-            .unwrap_or(1);
+            .unwrap_or(0);
 
         let action_type = match &payload {
             ProposalPayload::AddAdmin(_) => AdminActionType::AdminAdded,

--- a/dongle-smartcontract/src/tests/multisig_and_history.rs
+++ b/dongle-smartcontract/src/tests/multisig_and_history.rs
@@ -146,6 +146,33 @@ fn test_admin_multisig_approval_threshold() {
 }
 
 #[test]
+fn test_proposal_ids_start_at_zero() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin1) = setup_contract(&env);
+
+    let admin2 = Address::generate(&env);
+    let admin3 = Address::generate(&env);
+    client.add_admin(&admin1, &admin2);
+    client.add_admin(&admin1, &admin3);
+
+    // First proposal should get ID 0
+    let payload1 = ProposalPayload::AddAdmin(Address::generate(&env));
+    let id1 = client.create_proposal(&admin1, &payload1);
+    assert_eq!(id1, 0);
+
+    // Second proposal should get ID 1
+    let payload2 = ProposalPayload::AddAdmin(Address::generate(&env));
+    let id2 = client.create_proposal(&admin2, &payload2);
+    assert_eq!(id2, 1);
+
+    // Third proposal should get ID 2
+    let payload3 = ProposalPayload::AddAdmin(Address::generate(&env));
+    let id3 = client.create_proposal(&admin3, &payload3);
+    assert_eq!(id3, 2);
+}
+
+#[test]
 fn test_execute_proposal_rejects_corrupted_payload() {
     let env = Env::default();
     env.mock_all_auths();

--- a/scripts/dongle-smartcontract/src/admin_manager.rs
+++ b/scripts/dongle-smartcontract/src/admin_manager.rs
@@ -225,7 +225,7 @@ impl AdminManager {
             .storage()
             .persistent()
             .get(&crate::storage_keys::ExtensionKey::NextAdminProposalId)
-            .unwrap_or(1);
+            .unwrap_or(0);
 
         let action_type = match &payload {
             ProposalPayload::AddAdmin(_) => AdminActionType::AdminAdded,


### PR DESCRIPTION
## Summary

Fixes the proposal ID initialization bug in create_proposal() where unwrap_or(1) caused the counter to start at 1, leaving ID 0 unused and creating an off-by-one gap in zero-based indexing.

## Problem

In dmin_manager.rs::create_proposal(), the proposal ID counter defaults to 1 via unwrap_or(1) when NextAdminProposalId is not yet stored. This means:
- First proposal → ID 1, counter set to 2
- ID 0 is never used

## Fix

Changed unwrap_or(1) to unwrap_or(0) in both:
- dongle-smartcontract/src/admin_manager.rs:248
- scripts/dongle-smartcontract/src/admin_manager.rs:228

Now the first proposal correctly gets ID 0, with sequential incrementing from there.

## Test Added

	est_proposal_ids_start_at_zero — creates three proposals sequentially and asserts IDs are 0, 1, 2 respectively, verifying zero-based sequential assignment.

## Testing

Note: cargo test requires MSVC build tools not available in this environment. The change is a single default value swap (1 → 