### PR TITLE
docs: add invoke.sh examples for proposal workflow

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -161,6 +161,89 @@ soroban contract inspect \
 
 ---
 
+## Post-Deploy Governance Operations
+
+After initialize, privileged admin changes (adding/removing admins, raising the approval threshold, fee updates, verification decisions) can be executed directly **only while** `get_admin_approval_threshold` is `1`. Once the threshold is greater than `1`, those mutations must go through the multi-sig proposal workflow: `create_proposal` → `approve_proposal` → `execute_proposal`.
+
+Use [`scripts/invoke.sh`](scripts/invoke.sh). Each call is signed by `DEPLOYER_IDENTITY` (the admin whose key is used for that step). Export `CONTRACT_ID` or keep `.contract_id` from deploy.
+
+### 1. Bootstrap additional admins (threshold still 1)
+
+```bash
+export NETWORK=testnet
+export DEPLOYER_IDENTITY=alice          # current admin identity
+
+# Add co-admins while single-admin mode still allows direct add_admin
+./scripts/invoke.sh add_admin "$(soroban keys address bob)"
+./scripts/invoke.sh add_admin "$(soroban keys address carol)"
+
+# Require two approvals before a proposal can execute
+./scripts/invoke.sh set_admin_approval_threshold 2
+./scripts/invoke.sh get_admin_approval_threshold
+```
+
+Direct `add_admin` / `remove_admin` now returns `Unauthorized`. Use proposals instead.
+
+### 2. Create a proposal
+
+Example: propose adding a fourth admin. The proposer is counted as the first approval.
+
+```bash
+export DEPLOYER_IDENTITY=alice
+./scripts/invoke.sh create_proposal add_admin "$(soroban keys address dave)"
+```
+
+The invoke prints the new `proposal_id` (for example `1`). Inspect it:
+
+```bash
+./scripts/invoke.sh get_proposal 1
+```
+
+Other payloads supported by the helper:
+
+```bash
+./scripts/invoke.sh create_proposal remove_admin <admin_address>
+./scripts/invoke.sh create_proposal set_threshold 3
+./scripts/invoke.sh create_proposal set_fee none 1000 500 <treasury_address>
+./scripts/invoke.sh create_proposal approve_verification 1
+./scripts/invoke.sh create_proposal reject_verification 1
+./scripts/invoke.sh create_proposal revoke_verification 1 "policy violation"
+```
+
+### 3. Collect approvals
+
+A second distinct admin must approve until `approvals.len() >= threshold`. The original proposer cannot approve twice.
+
+```bash
+export DEPLOYER_IDENTITY=bob
+./scripts/invoke.sh approve_proposal 1
+
+./scripts/invoke.sh get_proposal 1
+# status should be Approved when the threshold is met
+```
+
+### 4. Execute the proposal
+
+Any admin (including one who has not approved) can execute once the threshold is met. Execution applies the payload (here, adding `dave` as admin) and marks the proposal `Executed`.
+
+```bash
+export DEPLOYER_IDENTITY=carol
+./scripts/invoke.sh execute_proposal 1
+
+./scripts/invoke.sh get_proposal 1
+./scripts/invoke.sh is_admin "$(soroban keys address dave)"
+```
+
+Re-executing an already executed proposal fails with `InvalidStatus`.
+
+### Threshold 1 shortcut
+
+If the threshold is still `1`, `create_proposal` is auto-approved (the proposer's vote meets the threshold). Skip `approve_proposal` and call `execute_proposal` immediately.
+
+For operational key rotation with this flow, see [docs/ADMIN_ROTATION_PLAYBOOK.md](docs/ADMIN_ROTATION_PLAYBOOK.md).
+
+---
+
 ## CI/CD Validation
 
 To prevent invalid, broken, or undocumented deployments from entering the `main` branch, the CI/CD pipeline runs `scripts/validate_deployments.py` on every push and pull request. If the script fails, the CI check will fail, blocking merges.

--- a/dongle-smartcontract/README.md
+++ b/dongle-smartcontract/README.md
@@ -100,6 +100,12 @@ Use the invocation helper script for common functions:
 
 # Fetch project details by Slug
 ./scripts/invoke.sh get_project_by_slug "my-project"
+
+# Multi-sig governance (see Admin Management below)
+./scripts/invoke.sh create_proposal add_admin <new_admin_address>
+./scripts/invoke.sh approve_proposal <proposal_id>
+./scripts/invoke.sh execute_proposal <proposal_id>
+./scripts/invoke.sh get_proposal <proposal_id>
 ```
 
 > [!IMPORTANT]
@@ -570,6 +576,84 @@ soroban contract invoke \
 |---|---|
 | `CannotRemoveLastAdmin` | Removing this admin would leave the contract with no admins |
 | `AdminNotFound` | The address to remove is not an admin |
+| `Unauthorized` | Caller is not an admin, or `get_admin_approval_threshold() > 1` (use the proposal workflow) |
+
+#### Multi-sig proposal workflow
+
+When the approval threshold is greater than `1`, `add_admin`, `remove_admin`, and further threshold changes cannot be called directly. Use `scripts/invoke.sh` with a different `DEPLOYER_IDENTITY` for each admin.
+
+**Step 1 — Raise the threshold** (still allowed while threshold is `1`):
+
+```bash
+export NETWORK=testnet
+export CONTRACT_ID=<CONTRACT_ID>
+export DEPLOYER_IDENTITY=alice
+
+./scripts/invoke.sh add_admin "$(soroban keys address bob)"
+./scripts/invoke.sh add_admin "$(soroban keys address carol)"
+./scripts/invoke.sh set_admin_approval_threshold 2
+```
+
+**Step 2 — Create a proposal** (`create_proposal`). The proposer is recorded as the first approval. Returns `proposal_id`.
+
+```bash
+export DEPLOYER_IDENTITY=alice
+./scripts/invoke.sh create_proposal add_admin "$(soroban keys address dave)"
+./scripts/invoke.sh get_proposal 1
+```
+
+Equivalent raw invoke:
+
+```bash
+soroban contract invoke \
+  --id <CONTRACT_ID> \
+  --source alice \
+  --network testnet \
+  -- create_proposal \
+  --proposer <ALICE_ADDRESS> \
+  --payload '{"AddAdmin":"<DAVE_ADDRESS>"}'
+```
+
+Supported helper payloads: `add_admin`, `remove_admin`, `set_threshold`, `set_fee`, `approve_verification`, `reject_verification`, `revoke_verification`.
+
+**Step 3 — Approve** (`approve_proposal`) with a *different* admin until the threshold is met. Duplicate approval by the same admin fails.
+
+```bash
+export DEPLOYER_IDENTITY=bob
+./scripts/invoke.sh approve_proposal 1
+```
+
+```bash
+soroban contract invoke \
+  --id <CONTRACT_ID> \
+  --source bob \
+  --network testnet \
+  -- approve_proposal \
+  --admin <BOB_ADDRESS> \
+  --proposal_id 1
+```
+
+**Step 4 — Execute** (`execute_proposal`) once status is `Approved`. This applies the payload and sets status to `Executed`.
+
+```bash
+export DEPLOYER_IDENTITY=carol
+./scripts/invoke.sh execute_proposal 1
+./scripts/invoke.sh is_admin "$(soroban keys address dave)"
+```
+
+```bash
+soroban contract invoke \
+  --id <CONTRACT_ID> \
+  --source carol \
+  --network testnet \
+  -- execute_proposal \
+  --caller <CAROL_ADDRESS> \
+  --proposal_id 1
+```
+
+If the threshold is `1`, skip step 3: creating the proposal already satisfies the threshold, so any admin can `execute_proposal` immediately.
+
+A full deploy-then-govern walkthrough lives in the root [Deployment Documentation](../DEPLOYMENT.md#post-deploy-governance-operations).
 
 #### Check Admin Status
 

--- a/scripts/invoke.sh
+++ b/scripts/invoke.sh
@@ -42,6 +42,25 @@ usage() {
     echo "  $0 pay_fee <payer_address> <project_id> <token_address_or_none>"
     echo "  $0 request_verification <project_id> <requester_address> <evidence_cid>"
     echo ""
+    echo "Governance / multi-sig proposals:"
+    echo "  $0 add_admin <new_admin_address>"
+    echo "  $0 set_admin_approval_threshold <n>"
+    echo "  $0 get_admin_approval_threshold"
+    echo "  $0 is_admin <address>"
+    echo "  $0 create_proposal add_admin <new_admin_address>"
+    echo "  $0 create_proposal remove_admin <admin_address>"
+    echo "  $0 create_proposal set_threshold <n>"
+    echo "  $0 create_proposal set_fee <token_or_none> <verification_fee> <registration_fee> <treasury>"
+    echo "  $0 create_proposal approve_verification <project_id>"
+    echo "  $0 create_proposal reject_verification <project_id>"
+    echo "  $0 create_proposal revoke_verification <project_id> <reason>"
+    echo "  $0 approve_proposal <proposal_id>"
+    echo "  $0 execute_proposal <proposal_id>"
+    echo "  $0 get_proposal <proposal_id>"
+    echo ""
+    echo "Each command is signed by DEPLOYER_IDENTITY. Switch that identity (or source"
+    echo "a different .env) when a different admin must create, approve, or execute."
+    echo ""
     exit 1
 }
 
@@ -179,6 +198,207 @@ case "$CMD" in
           --project_id "$PROJECT_ID" \
           --requester "$REQUESTER" \
           --evidence_cid "$EVIDENCE"
+        ;;
+
+    add_admin)
+        if [ $# -ne 1 ]; then
+            echo "Error: add_admin command requires exactly 1 argument: new_admin_address"
+            exit 1
+        fi
+        NEW_ADMIN="$1"
+        CALLER="$(soroban keys address "$DEPLOYER_IDENTITY")"
+
+        echo "Invoking add_admin..."
+        soroban contract invoke \
+          --id "$CONTRACT_ID" \
+          --source "$DEPLOYER_IDENTITY" \
+          --network "$NETWORK" \
+          -- add_admin \
+          --caller "$CALLER" \
+          --new_admin "$NEW_ADMIN"
+        ;;
+
+    set_admin_approval_threshold)
+        if [ $# -ne 1 ]; then
+            echo "Error: set_admin_approval_threshold command requires exactly 1 argument: n"
+            exit 1
+        fi
+        THRESHOLD="$1"
+        CALLER="$(soroban keys address "$DEPLOYER_IDENTITY")"
+
+        echo "Invoking set_admin_approval_threshold..."
+        soroban contract invoke \
+          --id "$CONTRACT_ID" \
+          --source "$DEPLOYER_IDENTITY" \
+          --network "$NETWORK" \
+          -- set_admin_approval_threshold \
+          --caller "$CALLER" \
+          --threshold "$THRESHOLD"
+        ;;
+
+    get_admin_approval_threshold)
+        echo "Invoking get_admin_approval_threshold..."
+        soroban contract invoke \
+          --id "$CONTRACT_ID" \
+          --source "$DEPLOYER_IDENTITY" \
+          --network "$NETWORK" \
+          -- get_admin_approval_threshold
+        ;;
+
+    is_admin)
+        if [ $# -ne 1 ]; then
+            echo "Error: is_admin command requires exactly 1 argument: address"
+            exit 1
+        fi
+        ADDRESS="$1"
+
+        echo "Invoking is_admin..."
+        soroban contract invoke \
+          --id "$CONTRACT_ID" \
+          --source "$DEPLOYER_IDENTITY" \
+          --network "$NETWORK" \
+          -- is_admin \
+          --address "$ADDRESS"
+        ;;
+
+    create_proposal)
+        if [ $# -lt 1 ]; then
+            echo "Error: create_proposal requires a payload type."
+            echo "  $0 create_proposal add_admin <new_admin_address>"
+            echo "  $0 create_proposal remove_admin <admin_address>"
+            echo "  $0 create_proposal set_threshold <n>"
+            echo "  $0 create_proposal set_fee <token_or_none> <verification_fee> <registration_fee> <treasury>"
+            echo "  $0 create_proposal approve_verification <project_id>"
+            echo "  $0 create_proposal reject_verification <project_id>"
+            echo "  $0 create_proposal revoke_verification <project_id> <reason>"
+            exit 1
+        fi
+        PAYLOAD_KIND="$1"
+        shift
+        PROPOSER="$(soroban keys address "$DEPLOYER_IDENTITY")"
+
+        case "$PAYLOAD_KIND" in
+            add_admin)
+                if [ $# -ne 1 ]; then
+                    echo "Error: create_proposal add_admin requires new_admin_address"
+                    exit 1
+                fi
+                PAYLOAD="{\"AddAdmin\":\"$1\"}"
+                ;;
+            remove_admin)
+                if [ $# -ne 1 ]; then
+                    echo "Error: create_proposal remove_admin requires admin_address"
+                    exit 1
+                fi
+                PAYLOAD="{\"RemoveAdmin\":\"$1\"}"
+                ;;
+            set_threshold)
+                if [ $# -ne 1 ]; then
+                    echo "Error: create_proposal set_threshold requires n"
+                    exit 1
+                fi
+                PAYLOAD="{\"SetThreshold\":$1}"
+                ;;
+            set_fee)
+                if [ $# -ne 4 ]; then
+                    echo "Error: create_proposal set_fee requires token_or_none, verification_fee, registration_fee, treasury"
+                    exit 1
+                fi
+                TOKEN_ARG="$1"
+                if [ "$TOKEN_ARG" = "none" ] || [ "$TOKEN_ARG" = "None" ] || [ "$TOKEN_ARG" = "null" ]; then
+                    TOKEN="null"
+                else
+                    TOKEN="\"$TOKEN_ARG\""
+                fi
+                PAYLOAD="{\"SetFee\":[$TOKEN,\"$2\",\"$3\",\"$4\"]}"
+                ;;
+            approve_verification)
+                if [ $# -ne 1 ]; then
+                    echo "Error: create_proposal approve_verification requires project_id"
+                    exit 1
+                fi
+                PAYLOAD="{\"ApproveVerification\":$1}"
+                ;;
+            reject_verification)
+                if [ $# -ne 1 ]; then
+                    echo "Error: create_proposal reject_verification requires project_id"
+                    exit 1
+                fi
+                PAYLOAD="{\"RejectVerification\":$1}"
+                ;;
+            revoke_verification)
+                if [ $# -ne 2 ]; then
+                    echo "Error: create_proposal revoke_verification requires project_id and reason"
+                    exit 1
+                fi
+                PAYLOAD="{\"RevokeVerification\":[$1,\"$2\"]}"
+                ;;
+            *)
+                echo "Unknown proposal payload type: $PAYLOAD_KIND"
+                usage
+                ;;
+        esac
+
+        echo "Invoking create_proposal ($PAYLOAD_KIND)..."
+        soroban contract invoke \
+          --id "$CONTRACT_ID" \
+          --source "$DEPLOYER_IDENTITY" \
+          --network "$NETWORK" \
+          -- create_proposal \
+          --proposer "$PROPOSER" \
+          --payload "$PAYLOAD"
+        ;;
+
+    approve_proposal)
+        if [ $# -ne 1 ]; then
+            echo "Error: approve_proposal command requires exactly 1 argument: proposal_id"
+            exit 1
+        fi
+        PROPOSAL_ID="$1"
+        ADMIN="$(soroban keys address "$DEPLOYER_IDENTITY")"
+
+        echo "Invoking approve_proposal..."
+        soroban contract invoke \
+          --id "$CONTRACT_ID" \
+          --source "$DEPLOYER_IDENTITY" \
+          --network "$NETWORK" \
+          -- approve_proposal \
+          --admin "$ADMIN" \
+          --proposal_id "$PROPOSAL_ID"
+        ;;
+
+    execute_proposal)
+        if [ $# -ne 1 ]; then
+            echo "Error: execute_proposal command requires exactly 1 argument: proposal_id"
+            exit 1
+        fi
+        PROPOSAL_ID="$1"
+        CALLER="$(soroban keys address "$DEPLOYER_IDENTITY")"
+
+        echo "Invoking execute_proposal..."
+        soroban contract invoke \
+          --id "$CONTRACT_ID" \
+          --source "$DEPLOYER_IDENTITY" \
+          --network "$NETWORK" \
+          -- execute_proposal \
+          --caller "$CALLER" \
+          --proposal_id "$PROPOSAL_ID"
+        ;;
+
+    get_proposal)
+        if [ $# -ne 1 ]; then
+            echo "Error: get_proposal command requires exactly 1 argument: proposal_id"
+            exit 1
+        fi
+        PROPOSAL_ID="$1"
+
+        echo "Invoking get_proposal..."
+        soroban contract invoke \
+          --id "$CONTRACT_ID" \
+          --source "$DEPLOYER_IDENTITY" \
+          --network "$NETWORK" \
+          -- get_proposal \
+          --proposal_id "$PROPOSAL_ID"
         ;;
 
     *)


### PR DESCRIPTION
## Summary
- Add `scripts/invoke.sh` helpers for the multi-sig proposal workflow (`create_proposal`, `approve_proposal`, `execute_proposal`, plus `get_proposal` and related admin setup commands).
- Document a step-by-step governance walkthrough in `DEPLOYMENT.md` and `dongle-smartcontract/README.md`.

## Type of Change
- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Refactoring / Documentation update

## Changes Made
- Extended `scripts/invoke.sh` with proposal payload helpers (`add_admin`, `remove_admin`, `set_threshold`, `set_fee`, verification actions) and `approve_proposal` / `execute_proposal` / `get_proposal`.
- Added a post-deploy governance section to `DEPLOYMENT.md` covering bootstrap, create, approve, and execute.
- Added matching step-by-step examples under Admin Management in `dongle-smartcontract/README.md`.

## Acceptance Criteria
- [x] Example invocations exist for `create_proposal`, `approve_proposal`, and `execute_proposal`.
- [x] `DEPLOYMENT.md` includes step-by-step script examples for governance operations.
- [x] `dongle-smartcontract/README.md` includes the same workflow using `invoke.sh`.

## Test Coverage
- `bash -n scripts/invoke.sh`

## Related Issues
Closes #510

Made with [Cursor](https://cursor.com)