### PR TITLE
refactor: remove duplicate bounty_url validation in register_project

### DIFF
--- a/dongle-smartcontract/src/project_registry.rs
+++ b/dongle-smartcontract/src/project_registry.rs
@@ -91,9 +91,6 @@ impl ProjectRegistry {
         if let Some(social_links) = &params.social_links {
             Utils::validate_social_links(social_links)?;
         }
-        if let Some(bounty_url) = &params.bounty_url {
-            Utils::validate_website(bounty_url)?;
-        }
 
         Self::ensure_owner_capacity(env, &params.owner)?;
 


### PR DESCRIPTION
## Summary

In `project_registry.rs::register_project()`, the `bounty_url` field was validated twice with two separate calls to `Utils::validate_website(&params.bounty_url)`. This was a copy-paste error.

## Changes

- Removed the redundant second `Utils::validate_website(&params.bounty_url)` call that appeared after the `social_links` validation block in `register_project()`
- The first validation call (alongside `website`, `logo_cid`, and `metadata_cid`) is retained

## Related Issue

Closes #500