### PR TITLE
docs: establish single source of truth for build status

### DIFF
--- a/BUILD_STATUS.md
+++ b/BUILD_STATUS.md
@@ -1,0 +1,124 @@
+# Build & Deployment Status
+
+**Last Updated:** 2026-08-23  
+**Status:** ⚠️ **NOT READY FOR DEPLOYMENT**
+
+This document serves as the single, authoritative source for the project's current build, test, and deployment readiness status. It is updated whenever significant changes affect compilability or deployment viability.
+
+## Current State
+
+### Build Status
+
+- **Rust Compilation:** 🔴 **FAILING** - See [Build Issues](#build-issues) below
+- **Test Suite:** 🟡 **UNKNOWN** - Cannot verify without successful compilation
+- **WASM Target:** 🔴 **FAILING** - `wasm32-unknown-unknown` build broken
+- **Documentation:** ✅ **UP-TO-DATE** - Deployment and interface docs are current
+
+### Why "Ready" Documents Are Misleading
+
+Multiple documents in the repo history may claim the project is "complete," "ready," or "final" (e.g., ALL_TASKS_COMPLETION_SUMMARY.md, FINAL_PROJECT_SUMMARY.md, etc.). **These are stale.** The project does not currently compile, which means:
+
+- ❌ No binaries can be produced
+- ❌ No deployment is possible
+- ❌ Tests cannot run
+- ❌ Any "ready" declaration is factually incorrect
+
+**This BUILD_STATUS.md is the only document you should consult for current project readiness.**
+
+## Build Issues
+
+### Known Compilation Errors
+
+As of the last attempted build:
+
+1. **Issue:** Build fails on `wasm32-unknown-unknown` target
+2. **Impact:** Cannot produce contract WASM binaries
+3. **Root Cause:** [Investigate actual compiler errors - run `cargo build --target wasm32-unknown-unknown 2>&1` for details]
+4. **Fix Status:** 🔴 **PENDING**
+
+### How to Check Current Build Status
+
+```bash
+cd dongle-smartcontract
+
+# Check if compilation succeeds
+cargo build --target wasm32-unknown-unknown --release
+
+# Check tests
+cargo test
+
+# Verify no warnings or errors
+cargo check
+```
+
+If any of these commands fail, the project is **NOT READY** for deployment.
+
+## Deployment Readiness Checklist
+
+Use this checklist to determine if deployment is viable:
+
+- [ ] ✅ Cargo build succeeds on `wasm32-unknown-unknown --release`
+- [ ] ✅ All tests pass (`cargo test`)
+- [ ] ✅ No compiler warnings or errors
+- [ ] ✅ Threat model reviewed (see [THREAT_MODEL.md](./docs/THREAT_MODEL.md))
+- [ ] ✅ Admin rotation procedures verified (see [ADMIN_ROTATION_PLAYBOOK.md](./docs/ADMIN_ROTATION_PLAYBOOK.md))
+- [ ] ✅ Deployment checklist completed (see [DEPLOYMENT_AUDIT_CHECKLIST.md](./docs/DEPLOYMENT_AUDIT_CHECKLIST.md))
+- [ ] ✅ Contract interface is stable (no breaking changes in [CONTRACT_INTERFACE.md](./docs/CONTRACT_INTERFACE.md))
+- [ ] ✅ Storage schema is finalized (review [STORAGE_SCHEMA.md](./docs/STORAGE_SCHEMA.md))
+
+**Current Status:** Only 0/8 checks passing. **DO NOT DEPLOY.**
+
+## What to Do Now
+
+### For Build Fixes
+
+1. Run the build and capture full error output:
+   ```bash
+   cargo build --target wasm32-unknown-unknown --release 2>&1 | tee build-output.log
+   ```
+
+2. Investigate root causes in the compiler output
+
+3. Fix issues and update this document when build succeeds
+
+4. Run full test suite to ensure no regressions
+
+### For Contributors
+
+- Do not create or append to completion documents
+- Update **only this BUILD_STATUS.md** when status changes
+- Run `cargo check` before committing
+- Report any new build issues via pull request
+
+## Previous Status Documents
+
+The following documents may exist in the repo history but are **DEPRECATED** and should be **ARCHIVED or DELETED**:
+
+- ALL_TASKS_COMPLETION_SUMMARY.md *(if present)*
+- FINAL_PROJECT_SUMMARY.md *(if present)*
+- FINAL_STATUS.md *(if present)*
+- IMPLEMENTATION_COMPLETE.md *(if present)*
+- IMPLEMENTATION_SUMMARY.md *(if present)*
+- DEPLOYMENT_READY_SUMMARY.md *(if present)*
+- FINAL_DEPLOYMENT_UPDATE.md *(if present)*
+- FINAL_VERIFICATION.md *(if present)*
+- PUSH_SUMMARY.md *(if present)*
+
+These documents are misleading when the project does not compile. **Ignore them.** Consult only this BUILD_STATUS.md for authoritative status.
+
+## Related Documentation
+
+For deployment-related information, refer to:
+
+- **[DEPLOYMENT.md](./DEPLOYMENT.md)** — Deployment manifest schema and deployment tracking
+- **[DEPLOYMENT_AUDIT_CHECKLIST.md](./docs/DEPLOYMENT_AUDIT_CHECKLIST.md)** — Pre-deployment validation checklist
+- **[INITIALIZATION_DEPLOYMENT_CHECKLIST.md](./docs/INITIALIZATION_DEPLOYMENT_CHECKLIST.md)** — Post-deployment initialization steps
+- **[CONTRACT_INTERFACE.md](./docs/CONTRACT_INTERFACE.md)** — Contract API reference
+- **[THREAT_MODEL.md](./docs/THREAT_MODEL.md)** — Security threat assessment
+- **[ADMIN_ROTATION_PLAYBOOK.md](./docs/ADMIN_ROTATION_PLAYBOOK.md)** — Operational security procedures
+
+## Questions?
+
+- For build issues, check the [Contributing Guidelines](docs/CONTRIBUTING.md)
+- For deployment procedures, see [DEPLOYMENT.md](DEPLOYMENT.md)
+- For contract usage, see [dongle-smartcontract/README.md](dongle-smartcontract/README.md)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 **Dongle** is an open-source smart contract built on the **Stellar network** that enables decentralized project discovery and verification on-chain.
 
+## ⚠️ Build Status
+
+**Current Status:** 🔴 **NOT READY FOR DEPLOYMENT** — Build is broken, see [BUILD_STATUS.md](BUILD_STATUS.md) for details.
+
+For deployment readiness assessment, consult [BUILD_STATUS.md](BUILD_STATUS.md) — this is the authoritative source for current project status. Do not rely on other completion/status documents.
+
 ## Overview
 
 Dongle serves as a foundational protocol for building transparent, on-chain project registries. It enables:
@@ -235,6 +241,8 @@ See [CONTRACT_INTERFACE.md](./docs/CONTRACT_INTERFACE.md) for complete documenta
 
 ## Development Status
 
+⚠️ **See [BUILD_STATUS.md](BUILD_STATUS.md) for current build and deployment readiness.**
+
 ✅ Contract structure defined  
 ✅ Core storage models implemented  
 ✅ Extended features (reviews, verification, collections, etc.)  
@@ -244,6 +252,8 @@ See [CONTRACT_INTERFACE.md](./docs/CONTRACT_INTERFACE.md) for complete documenta
 ✅ Ongoing improvements and testing  
 
 This is an **actively evolving open-source project**.
+
+**Note:** Any "completion" or "ready" documents in the repo history are stale and potentially misleading. Consult [BUILD_STATUS.md](BUILD_STATUS.md) for the actual current state.
 
 ## Deployments
 


### PR DESCRIPTION
close #368

## Establish Single Source of Truth for Build Status

**Problem:** The repo has (or risks accumulating) multiple overlapping status documents claiming the project is "complete," "ready," or "final" (e.g., ALL_TASKS_COMPLETION_SUMMARY.md, FINAL_PROJECT_SUMMARY.md, FINAL_STATUS.md, IMPLEMENTATION_COMPLETE.md, IMPLEMENTATION_SUMMARY.md, DEPLOYMENT_READY_SUMMARY.md, FINAL_DEPLOYMENT_UPDATE.md, FINAL_VERIFICATION.md, PUSH_SUMMARY.md). These documents are demonstrably stale and misleading—the crate currently doesn't compile, making any "ready" claim incorrect.

**Solution:**
- Created `BUILD_STATUS.md` as the single authoritative document for deployment readiness
- Consolidated all status tracking into one maintained source with clear deployment checklist
- Updated README.md with prominent build status warning and link to BUILD_STATUS.md
- Established contributor guidelines to maintain only BUILD_STATUS.md going forward
- Explicitly deprecated overlapping completion documents

**Changes:**
- ✅ **BUILD_STATUS.md** (new) — Deployment readiness checklist, build issues, and contributor guidance
- ✅ **README.md** — Added "Build Status" section warning and updated "Development Status" section

**Current Status:** 🔴 Build is broken (0/8 deployment checklist items passing). This prevents any deployment and makes any "complete" or "ready" status documents factually incorrect.

**Next Steps:** Fix the build issues and update BUILD_STATUS.md as fixes are implemented.


