### PR TITLE
fix: remove unused test_project workspace crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1658,10 +1658,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "test_project"
-version = "0.1.0"
-
-[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["dongle-smartcontract", "test_project"]
+members = ["dongle-smartcontract"]
 resolver = "2"

--- a/test_project/Cargo.toml
+++ b/test_project/Cargo.toml
@@ -1,6 +1,0 @@
-[package]
-name = "test_project"
-version = "0.1.0"
-edition = "2021"
-
-[dependencies]

--- a/test_project/src/main.rs
+++ b/test_project/src/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("Hello, world!");
-}


### PR DESCRIPTION
close #366 

## Remove Unused test_project Workspace Crate

**Problem:** The `test_project` crate in the workspace is a placeholder with no real purpose, yet it adds unnecessary build overhead to every workspace-wide `cargo build`/`cargo check` command.

**Evidence:**
- **Added:** June 2026 during "prepare for deployment" commit
- **Contents:** Only a `Cargo.toml` with no dependencies and `src/main.rs` containing a single `println!("Hello, world!");`
- **Purpose:** None identified. Tests use fixture functions in the contract crate, not from this workspace member
- **Impact:** Increases compilation time for developers and CI without providing any value

**Solution:**
- Removed `test_project/` directory entirely
- Updated `Cargo.toml` to remove `test_project` from workspace members
- Updated `Cargo.lock` to reflect the removal

**Benefits:**
- ✅ Faster workspace builds and checks
- ✅ Clearer project structure for contributors
- ✅ No loss of functionality (all tests remain in the contract crate)
- ✅ Reduced CI overhead

**Note:** The `create_test_project` fixture function used in contract tests is defined in `dongle-smartcontract/src/tests/fixtures.rs`, so test coverage is unaffected.
